### PR TITLE
fix: téléchargement direct du binaire trivy dans le scan central

### DIFF
--- a/.github/workflows/central-scan.yml
+++ b/.github/workflows/central-scan.yml
@@ -46,7 +46,10 @@ jobs:
           GITLEAKS_VERSION=8.21.2
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C /tmp gitleaks
           sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
-          curl -sSfL "https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh" | sudo sh -s -- -b /usr/local/bin v0.58.1
+          # Download the release binary directly — trivy's contrib/install.sh is fragile
+          TRIVY_VERSION=0.58.1
+          curl -sSfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" | tar -xz -C /tmp trivy
+          sudo mv /tmp/trivy /usr/local/bin/trivy
           pipx install semgrep
           gitleaks version
           trivy --version


### PR DESCRIPTION
Hotfix du run 2 de Central Security Scan (échec en 15 s à l'étape *Install scanners*).

Le script `contrib/install.sh` de trivy résolvait la version (`found version: 0.58.1`) puis sortait en `exit 1` sans message — très probablement du rate-limiting API GitHub non authentifié depuis les runners. Remplacé par le téléchargement direct du tarball de release épinglé (`trivy_0.58.1_Linux-64bit.tar.gz`), même approche que pour gitleaks, sans aucun appel API.

À merger puis relancer **Central Security Scan**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_