### PR TITLE
fix: épingler trivy sur une release avec binaires (v0.72.0)

### DIFF
--- a/.github/workflows/central-scan.yml
+++ b/.github/workflows/central-scan.yml
@@ -47,7 +47,8 @@ jobs:
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C /tmp gitleaks
           sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
           # Download the release binary directly — trivy's contrib/install.sh is fragile
-          TRIVY_VERSION=0.58.1
+          # and old releases (e.g. 0.58.x) no longer carry binary assets
+          TRIVY_VERSION=0.72.0
           curl -sSfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" | tar -xz -C /tmp trivy
           sudo mv /tmp/trivy /usr/local/bin/trivy
           pipx install semgrep


### PR DESCRIPTION
Run 3 du Central Security Scan : `curl: (22) 404` sur le tarball trivy. Vérification faite sur les pages de releases : **la v0.58.1 (et 0.58.2) ne porte plus que les archives source** — aucun binaire attaché. C'est aussi la vraie cause de l'échec silencieux de `contrib/install.sh` au run 2. La v0.72.0 (latest, 30 juin) fournit bien `trivy_0.72.0_Linux-64bit.tar.gz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_