### PR TITLE
feat: redéploiement automatique des templates vers les repos gérés

### DIFF
--- a/.github/workflows/redeploy-templates.yml
+++ b/.github/workflows/redeploy-templates.yml
@@ -1,0 +1,63 @@
+# DevOps-Factory: Redeploy Templates
+# Propagates updated workflow templates to managed repos (one update PR per
+# repo whose deployed copy differs). Triggers automatically when templates
+# change on master, or manually via workflow_dispatch.
+
+name: Redeploy Templates
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'templates/**'
+      - '.github/workflows/redeploy-templates.yml'
+  workflow_dispatch:
+    inputs:
+      template:
+        description: 'Template to redeploy (name or "all")'
+        required: false
+        default: 'all'
+        type: string
+      dry_run:
+        description: 'Dry run (log only, no PRs)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: redeploy-templates
+  cancel-in-progress: false
+
+jobs:
+  redeploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Redeploy templates
+        run: |
+          ARGS="--template ${TEMPLATE:-all}"
+          if [ "$DRY_RUN" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          pnpm redeploy-templates -- $ARGS
+        env:
+          TEMPLATE: ${{ inputs.template }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          GH_TOKEN: ${{ secrets.FACTORY_PAT }}

--- a/scripts/redeploy-templates.ts
+++ b/scripts/redeploy-templates.ts
@@ -9,7 +9,7 @@
  */
 
 import { execSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { KNOWN_PROJECTS } from '../factory.config.js';
 import { sh, tmpDir } from './shell-utils.js';
 import { loadRepoConfig, renderTemplate } from './template-config.js';
@@ -142,6 +142,10 @@ const main = () => {
 
   for (const [name, config] of templatesToProcess) {
     console.log(`\n=== Template: ${name} ===`);
+    if (!existsSync(config.file)) {
+      console.log(`  source file ${config.file} missing (skip)`);
+      continue;
+    }
     const rawContent = readFileSync(config.file, 'utf-8');
 
     const eligibleProjects = KNOWN_PROJECTS.filter((p) => {


### PR DESCRIPTION
Nouveau workflow `redeploy-templates.yml` :

- **Déclenchement automatique** sur push de `templates/**` sur master (et à la création de ce workflow lui-même → il se lancera dès le merge de cette PR et propagera les templates allégés de #2143 vers les repos privés, une PR de mise à jour par repo)
- **Déclenchement manuel** possible avec choix du template et mode dry-run
- Fix au passage : `--template all` crashait car le registre référence `templates/coverage-tracking.yml` qui n'existe pas — les fichiers sources manquants sont maintenant ignorés avec un avertissement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_