### PR TITLE
fix: fallback sans label pour les issues du scan central

### DIFF
--- a/scripts/central-scan.ts
+++ b/scripts/central-scan.ts
@@ -423,9 +423,18 @@ const createIssue = (repo: string, title: string, body: string): void => {
   );
   const tmpFile = `${tmpDir}/central-scan-body.md`;
   writeFileSync(tmpFile, body);
-  sh(
+  const created = sh(
     `gh issue create --repo ${repo} --title "${title}" --body-file "${tmpFile}" --label "${LABEL}"`
   );
+  // gh refuses to create the issue when the label is missing (e.g. label
+  // creation was denied by token permissions) — an unlabeled issue beats
+  // silently losing the report
+  if (!created.includes('github.com')) {
+    const retry = sh(`gh issue create --repo ${repo} --title "${title}" --body-file "${tmpFile}"`);
+    if (!retry.includes('github.com')) {
+      console.log(`  [WARN] could not create central-scan issue on ${repo}`);
+    }
+  }
 };
 
 /** Counts-only consolidated issue on the (public) Factory repo. */


### PR DESCRIPTION
Run 4 du scan : `gh issue create --label` abandonne entièrement quand le label n'existe pas ; avec un token sous-permissionné, la création du label prenait un 403 et **tous les rapports d'issues étaient silencieusement perdus**. Retry sans label plutôt que de perdre le rapport.

(La cause première — PAT en lecture seule — se règle côté réglages du token, voir issue #2144.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_