### PR TITLE
fix: suites du run 5 — flag jscpd inexistant, timeout de clone, course au commit

### DIFF
--- a/.github/workflows/central-scan.yml
+++ b/.github/workflows/central-scan.yml
@@ -66,14 +66,18 @@ jobs:
         run: |
           git config user.name "DevOps Factory Bot"
           git config user.email "devops-factory[bot]@users.noreply.github.com"
-          git add data/central-scan-latest.json data/central-scan-report.md data/activity-log.json
+          # The scan takes ~20 min and hourly crons push to master meanwhile —
+          # re-apply the scan outputs onto the fresh remote head instead of
+          # rebasing. activity-log.json is deliberately NOT committed here:
+          # it is written by hourly workflows and would conflict every run.
+          cp data/central-scan-latest.json /tmp/central-scan-latest.json
+          cp data/central-scan-report.md /tmp/central-scan-report.md
+          git fetch origin master
+          git reset --hard origin/master
+          cp /tmp/central-scan-latest.json data/central-scan-latest.json
+          cp /tmp/central-scan-report.md data/central-scan-report.md
+          git add data/central-scan-latest.json data/central-scan-report.md
           git diff --cached --quiet || git commit -m "chore: update central scan report" --no-verify
-          if git pull --rebase --autostash; then
-            git push
-            exit 0
-          fi
-          git rebase --abort 2>/dev/null || true
-          git stash pop 2>/dev/null || true
-          git push
+          git push origin master
         env:
           GH_TOKEN: ${{ secrets.FACTORY_PAT }}

--- a/scripts/central-scan.ts
+++ b/scripts/central-scan.ts
@@ -342,7 +342,7 @@ const runJscpd = (dir: string): ScannerResult => {
   const outDir = `${tmpDir}/jscpd-out`;
   rmSync(outDir, { recursive: true, force: true });
   sh(
-    `"${JSCPD_BIN}" . --reporters json --output "${outDir}" --silent --gitignore ` +
+    `"${JSCPD_BIN}" . --reporters json --output "${outDir}" --silent ` +
       `--ignore "**/node_modules/**,**/dist/**,**/build/**,**/.next/**,**/coverage/**,**/*.min.js,**/pnpm-lock.yaml,**/package-lock.json,**/yarn.lock"`,
     { cwd: dir, timeout: SCAN_TIMEOUT_MS, maxBuffer: SCAN_MAX_BUFFER, fallbackOnError: 'stdout' }
   );
@@ -372,7 +372,7 @@ const scanRepo = (
 
   // Full clone: gitleaks scans the entire git history
   const cloned = sh(`gh repo clone ${project.repo} "${dir}" 2>&1 && echo OK`, {
-    timeout: 180_000,
+    timeout: 600_000,
     maxBuffer: SCAN_MAX_BUFFER,
     fallbackOnError: 'stdout',
   }).includes('OK');


### PR DESCRIPTION
Le run 5 a scanné les 25 repos avec succès (2434 findings, issues créées — voir #2152), mais trois anomalies restaient :

1. **jscpd en erreur sur tous les repos** : le CLI de jscpd 5 n'a pas de flag `--gitignore` → exit 2 systématique. Reproduit localement, flag retiré (la liste `--ignore` explicite couvre déjà les artefacts de build).
2. **Clone du repo DevOps-Factory tué** : timeout de 180 s trop court pour ~350 Mo d'historique → passé à 600 s.
3. **Échec du commit final** : pendant les 20 min de scan, le cron horaire ci-health-check a poussé sur master → conflit de rebase sur `data/activity-log.json`, puis push non-fast-forward du fallback. Le step ré-applique maintenant les fichiers du scan sur la tête distante fraîche, et ne committe plus `activity-log.json` (propriété des workflows horaires).

Après merge : relancer **Central Security Scan** une dernière fois pour obtenir la colonne duplication + les données dashboard committées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_