### PR TITLE
feat: Renovate centralisé self-hosted pour les 25 repos (P1 dépendances)

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,55 @@
+# DevOps-Factory: Central Renovate
+# Self-hosted Renovate run against every managed repo, from this public repo
+# (free Actions minutes) with FACTORY_PAT — no Mend app, no per-repo
+# renovate.json needed. Repo defaults come from templates/renovate.json via
+# scripts/central-renovate.ts; security updates (OSV) bypass schedules.
+
+name: Central Renovate
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # Daily 6am UTC (grouped non-major updates land on weekends per config)
+  workflow_dispatch:
+    inputs:
+      log_level:
+        description: 'Renovate log level'
+        required: false
+        default: 'info'
+        type: choice
+        options: [info, debug]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: central-renovate
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Renovate config
+        run: pnpm renovate-config -- --out /tmp/renovate-config.json
+
+      - name: Run Renovate
+        run: npx --yes renovate
+        env:
+          RENOVATE_CONFIG_FILE: /tmp/renovate-config.json
+          RENOVATE_TOKEN: ${{ secrets.FACTORY_PAT }}
+          LOG_LEVEL: ${{ inputs.log_level || 'info' }}

--- a/docs/central-renovate.md
+++ b/docs/central-renovate.md
@@ -1,0 +1,39 @@
+# Central Renovate
+
+## Pourquoi
+
+~400 vulnérabilités CRITICAL/HIGH de dépendances détectées par le scan
+central, et aucun repo n'avait Renovate. L'app Mend nécessiterait une
+installation + un `renovate.json` par repo ; à la place, **Renovate tourne en
+self-hosted depuis la Factory** (repo public = minutes Actions gratuites)
+avec `FACTORY_PAT`, contre tous les repos de `KNOWN_PROJECTS`.
+
+## Comment ça marche
+
+`.github/workflows/renovate.yml` (quotidien 6h UTC + manuel) :
+
+1. `pnpm renovate-config` (`scripts/central-renovate.ts`) génère la config
+   globale : liste des repos depuis `factory.config.ts` + défauts hérités de
+   `templates/renovate.json` (groupes, automerge, plafonds de PRs).
+2. `npx renovate` traite chaque repo et ouvre les PRs de mise à jour.
+
+Points clés :
+
+- **Sécurité d'abord** : `osvVulnerabilityAlerts` (base OSV, indépendante des
+  alertes Dependabot) — les PRs de vulnérabilités ignorent les plannings et
+  s'automergent (`vulnerabilityAlerts.automerge: true`).
+- **Quota-friendly** : mises à jour non-majeures groupées en une PR par repo
+  (planifiées le week-end), patchs devDependencies en automerge branche,
+  `prConcurrentLimit: 5` / `prHourlyLimit: 2` — la CI des repos privés n'est
+  pas noyée.
+- **Majeures** : jamais d'automerge, label `breaking`, revue manuelle.
+- Un `renovate.json` présent dans un repo **prend le dessus** sur les défauts
+  (`requireConfig: optional`, onboarding désactivé).
+- Le quality score accorde `depsUpToDate` à tous les repos couverts
+  (`CENTRAL_RENOVATE_ENABLED`).
+
+## Usage local
+
+```bash
+pnpm renovate-config -- --out /tmp/renovate-config.json  # inspecter la config générée
+```

--- a/factory.config.ts
+++ b/factory.config.ts
@@ -483,6 +483,12 @@ export const WEBHOOK_CONFIG: WebhookConfig = {
   enabled: true,
 };
 
+/**
+ * Central self-hosted Renovate (.github/workflows/renovate.yml) covers every
+ * repo in KNOWN_PROJECTS — no per-repo renovate.json needed.
+ */
+export const CENTRAL_RENOVATE_ENABLED = true;
+
 export const GITHUB_OWNER = 'thonyAGP';
 
 export const DASHBOARD_URL = 'https://thonyagp.github.io/DevOps-Factory/';

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "template-update": "tsx scripts/template-updater.ts",
     "security-posture": "tsx scripts/security-posture.ts",
     "central-scan": "tsx scripts/central-scan.ts",
+    "renovate-config": "tsx scripts/central-renovate.ts",
     "template-drift": "tsx scripts/template-drift.ts",
     "dora": "tsx scripts/dora-metrics.ts",
     "cost-monitor": "tsx scripts/cost-monitor.ts",

--- a/scripts/central-renovate.test.ts
+++ b/scripts/central-renovate.test.ts
@@ -1,0 +1,64 @@
+/**
+ * central-renovate.test.ts
+ *
+ * Unit tests for the central Renovate config generator.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildRenovateConfig, renovateRepositories } from './central-renovate.js';
+import type { ProjectConfig } from '../factory.config.js';
+
+const project = (over: Partial<ProjectConfig>): ProjectConfig => ({
+  name: 'X',
+  repo: 'thonyAGP/X',
+  hasCI: false,
+  stack: 'node',
+  hasQodo: false,
+  hasClaude: false,
+  hasSelfHealing: false,
+  hasHusky: false,
+  hasRenovate: false,
+  hasGitleaks: false,
+  hasLighthouse: false,
+  hasLinkChecker: false,
+  vercel: false,
+  ...over,
+});
+
+const TEMPLATE = JSON.stringify({
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: ['config:recommended'],
+  automerge: false,
+  packageRules: [{ matchUpdateTypes: ['patch'], automerge: true }],
+});
+
+describe('renovateRepositories', () => {
+  it('includes every managed repo, hidden ones too', () => {
+    const repos = renovateRepositories([
+      project({ repo: 'thonyAGP/A' }),
+      project({ repo: 'thonyAGP/B', hidden: true }),
+    ]);
+    expect(repos).toEqual(['thonyAGP/A', 'thonyAGP/B']);
+  });
+});
+
+describe('buildRenovateConfig', () => {
+  const config = buildRenovateConfig([project({ repo: 'thonyAGP/A' })], TEMPLATE);
+
+  it('sets self-hosted admin options', () => {
+    expect(config.platform).toBe('github');
+    expect(config.onboarding).toBe(false);
+    expect(config.requireConfig).toBe('optional');
+    expect(config.repositories).toEqual(['thonyAGP/A']);
+    expect(config.osvVulnerabilityAlerts).toBe(true);
+  });
+
+  it('inherits repo defaults from the template', () => {
+    expect(config.extends).toEqual(['config:recommended']);
+    expect(config.packageRules).toHaveLength(1);
+  });
+
+  it('strips the JSON schema pointer', () => {
+    expect(config['$schema']).toBeUndefined();
+  });
+});

--- a/scripts/central-renovate.ts
+++ b/scripts/central-renovate.ts
@@ -1,0 +1,69 @@
+/**
+ * central-renovate.ts
+ *
+ * Generates the global config for the self-hosted Renovate run
+ * (.github/workflows/renovate.yml). Renovate runs FROM the public Factory
+ * repo (free Actions minutes) against every managed repo with FACTORY_PAT —
+ * no Mend app install and no per-repo renovate.json required
+ * (requireConfig: optional — a repo-level renovate.json still wins if present).
+ *
+ * Repo defaults are inherited from templates/renovate.json so per-repo and
+ * central behavior stay identical (grouping, automerge, security alerts).
+ *
+ * Usage: pnpm renovate-config [-- --out /tmp/renovate-config.json]
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { KNOWN_PROJECTS, type ProjectConfig } from '../factory.config.js';
+
+const TEMPLATE_PATH = 'templates/renovate.json';
+
+export interface RenovateGlobalConfig {
+  platform: string;
+  onboarding: boolean;
+  requireConfig: string;
+  repositories: string[];
+  gitAuthor: string;
+  osvVulnerabilityAlerts: boolean;
+  [key: string]: unknown;
+}
+
+/** All managed repos — hidden ones included: their dependencies rot too. */
+export const renovateRepositories = (projects: ProjectConfig[]): string[] =>
+  projects.map((p) => p.repo);
+
+export const buildRenovateConfig = (
+  projects: ProjectConfig[],
+  templateJson: string
+): RenovateGlobalConfig => {
+  const defaults = JSON.parse(templateJson) as Record<string, unknown>;
+  delete defaults['$schema'];
+
+  return {
+    // Admin/self-hosted options
+    platform: 'github',
+    onboarding: false,
+    requireConfig: 'optional',
+    repositories: renovateRepositories(projects),
+    gitAuthor: 'DevOps Factory Bot <devops-factory[bot]@users.noreply.github.com>',
+    // Security updates from the OSV database, independent of GitHub
+    // Dependabot alerts (which private repos may not have enabled)
+    osvVulnerabilityAlerts: true,
+    // Repo-config defaults inherited from the per-repo template
+    ...defaults,
+  };
+};
+
+const main = (): void => {
+  const args = process.argv.slice(2);
+  const outIdx = args.indexOf('--out');
+  const outPath = outIdx >= 0 && args[outIdx + 1] ? args[outIdx + 1] : '/tmp/renovate-config.json';
+
+  const config = buildRenovateConfig(KNOWN_PROJECTS, readFileSync(TEMPLATE_PATH, 'utf-8'));
+  writeFileSync(outPath, JSON.stringify(config, null, 2));
+  console.log(`Renovate config written to ${outPath} (${config.repositories.length} repos)`);
+};
+
+const isDirectRun =
+  !process.env.VITEST && process.argv[1]?.replace(/\\/g, '/').endsWith('central-renovate.ts');
+if (isDirectRun) main();

--- a/scripts/quality-score.ts
+++ b/scripts/quality-score.ts
@@ -9,7 +9,12 @@
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
-import { KNOWN_PROJECTS, QUALITY_WEIGHTS, COVERAGE_THRESHOLDS } from '../factory.config.js';
+import {
+  KNOWN_PROJECTS,
+  QUALITY_WEIGHTS,
+  COVERAGE_THRESHOLDS,
+  CENTRAL_RENOVATE_ENABLED,
+} from '../factory.config.js';
 import { logActivity } from './activity-logger.js';
 import type { RepoScanResult } from './central-scan.js';
 import { sh, jq, devNull } from './shell-utils.js';
@@ -243,8 +248,10 @@ const evaluateRepo = (repo: (typeof KNOWN_PROJECTS)[0]): RepoQualityScore => {
     breakdown.branchProtection = 0;
   }
 
-  // Dependency management (renovate.json proxy)
+  // Dependency management: covered by the central Renovate run (all managed
+  // repos), or by a repo-level renovate config
   if (
+    CENTRAL_RENOVATE_ENABLED ||
     checkConfigExists(repo.repo, 'renovate.json') ||
     checkConfigExists(repo.repo, '.renovaterc')
   ) {


### PR DESCRIPTION
Résorbe les ~400 vulnérabilités CRITICAL/HIGH de dépendances détectées par le scan central — aucun repo n'avait Renovate.

## Architecture

Pas d'app Mend ni de `renovate.json` à déployer : **Renovate tourne en self-hosted depuis la Factory** (repo public = minutes gratuites), quotidiennement à 6h UTC, contre les 25 repos de `KNOWN_PROJECTS` avec `FACTORY_PAT`.

- `scripts/central-renovate.ts` (+ tests) génère la config globale : liste des repos + défauts hérités de `templates/renovate.json` — comportement identique entre central et per-repo
- **Sécurité d'abord** : `osvVulnerabilityAlerts` (base OSV, marche sans alertes Dependabot), les PRs de vulnérabilités ignorent les plannings et s'automergent
- **Quota-friendly** : non-majeures groupées en 1 PR/repo le week-end, `prConcurrentLimit 5`/`prHourlyLimit 2` — la CI des repos privés n'est pas noyée
- Majeures : jamais d'automerge, label `breaking`
- Un `renovate.json` local prend le dessus (`requireConfig: optional`)
- Quality score : `depsUpToDate` accordé aux repos couverts par le central
- Doc : `docs/central-renovate.md`

Après merge : premier run au cron de demain 6h UTC, ou immédiat via Actions → **Central Renovate** → Run workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_