### PR TITLE
feat: mesure centrale hebdomadaire de la couverture de tests (étape 1)

### DIFF
--- a/.github/workflows/central-coverage.yml
+++ b/.github/workflows/central-coverage.yml
@@ -1,0 +1,62 @@
+# DevOps-Factory: Central Coverage
+# Weekly real coverage measurement for node-stack repos, run from this public
+# repo (free minutes): clone, install, `vitest run --coverage`, then merge the
+# results into data/coverage-history.json (which quality-score and the
+# dashboard already read). coverage-baseline (daily) carries the measured
+# values forward between runs.
+
+name: Central Coverage
+
+on:
+  schedule:
+    - cron: '0 4 * * 0' # Weekly Sunday 4am UTC (before Monday's security scan)
+  workflow_dispatch:
+    inputs: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: central-coverage
+  cancel-in-progress: false
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.FACTORY_PAT }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Measure coverage (slow — clones and tests each repo)
+        run: pnpm central-coverage -- --measure --out /tmp/coverage-measurements.json
+        env:
+          GH_TOKEN: ${{ secrets.FACTORY_PAT }}
+
+      - name: Merge into coverage history and push
+        run: |
+          git config user.name "DevOps Factory Bot"
+          git config user.email "devops-factory[bot]@users.noreply.github.com"
+          # The measurement takes a long time and hourly crons push to master
+          # meanwhile — apply the results onto the fresh remote head
+          git fetch origin master
+          git reset --hard origin/master
+          pnpm central-coverage -- --apply /tmp/coverage-measurements.json
+          git add data/coverage-history.json data/activity-log.json
+          git diff --cached --quiet || git commit -m "chore: update coverage measurements" --no-verify
+          git push origin master
+        env:
+          GH_TOKEN: ${{ secrets.FACTORY_PAT }}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "security-posture": "tsx scripts/security-posture.ts",
     "central-scan": "tsx scripts/central-scan.ts",
     "renovate-config": "tsx scripts/central-renovate.ts",
+    "central-coverage": "tsx scripts/central-coverage.ts",
     "template-drift": "tsx scripts/template-drift.ts",
     "dora": "tsx scripts/dora-metrics.ts",
     "cost-monitor": "tsx scripts/cost-monitor.ts",

--- a/scripts/activity-logger.ts
+++ b/scripts/activity-logger.ts
@@ -39,7 +39,8 @@ export type ActivitySource =
   | 'dependency-intelligence'
   | 'auto-generate-tests'
   | 'knowledge-graph'
-  | 'central-scan';
+  | 'central-scan'
+  | 'central-coverage';
 
 export interface ActivityEntry {
   timestamp: string;

--- a/scripts/central-coverage.test.ts
+++ b/scripts/central-coverage.test.ts
@@ -1,0 +1,104 @@
+/**
+ * central-coverage.test.ts
+ *
+ * Unit tests for the central coverage measurement helpers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseCoverageSummary,
+  applyMeasurements,
+  type CoverageMeasurement,
+} from './central-coverage.js';
+
+describe('parseCoverageSummary', () => {
+  it('extracts rounded percentages from a vitest json-summary', () => {
+    const json = JSON.stringify({
+      total: {
+        lines: { pct: 72.345 },
+        branches: { pct: 61.5 },
+        functions: { pct: 80 },
+        statements: { pct: 72.345 },
+      },
+    });
+    expect(parseCoverageSummary(json)).toEqual({
+      lines: 72.35,
+      branches: 61.5,
+      functions: 80,
+      statements: 72.35,
+    });
+  });
+
+  it('returns null on missing total or invalid JSON', () => {
+    expect(parseCoverageSummary('{}')).toBeNull();
+    expect(parseCoverageSummary('not json')).toBeNull();
+  });
+});
+
+describe('applyMeasurements', () => {
+  const measurement = (repo: string, lines: number): CoverageMeasurement => ({
+    name: repo.split('/')[1],
+    repo,
+    stack: 'node',
+    testFramework: 'vitest',
+    hasTests: true,
+    testFileCount: 10,
+    coverage: { lines, branches: 50, functions: 50, statements: lines },
+    status: 'collected',
+  });
+
+  const baselineEntry = (repo: string): CoverageMeasurement => ({
+    name: repo.split('/')[1],
+    repo,
+    stack: 'node',
+    hasTests: true,
+    testFileCount: 10,
+    status: 'no-coverage',
+  });
+
+  it('overrides the daily baseline entry for measured repos', () => {
+    const history = {
+      version: 1,
+      lastUpdated: '',
+      entries: [{ date: '2026-07-06', repos: [baselineEntry('o/a'), baselineEntry('o/b')] }],
+    };
+    const result = applyMeasurements(history, [measurement('o/a', 72)], '2026-07-06');
+    const day = result.entries[0];
+    expect(day.repos.find((r) => r.repo === 'o/a')?.status).toBe('collected');
+    expect(day.repos.find((r) => r.repo === 'o/a')?.coverage?.lines).toBe(72);
+    // unmeasured repo keeps its baseline entry
+    expect(day.repos.find((r) => r.repo === 'o/b')?.status).toBe('no-coverage');
+  });
+
+  it('creates the day entry when none exists', () => {
+    const history = { version: 1, lastUpdated: '', entries: [] };
+    const result = applyMeasurements(history, [measurement('o/a', 60)], '2026-07-07');
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].date).toBe('2026-07-07');
+    expect(result.entries[0].repos).toHaveLength(1);
+  });
+
+  it('appends measured repos missing from the day entry', () => {
+    const history = {
+      version: 1,
+      lastUpdated: '',
+      entries: [{ date: '2026-07-06', repos: [baselineEntry('o/a')] }],
+    };
+    const result = applyMeasurements(history, [measurement('o/new', 55)], '2026-07-06');
+    expect(result.entries[0].repos.map((r) => r.repo)).toEqual(['o/a', 'o/new']);
+  });
+
+  it('does not touch other days', () => {
+    const history = {
+      version: 1,
+      lastUpdated: '',
+      entries: [
+        { date: '2026-07-01', repos: [baselineEntry('o/a')] },
+        { date: '2026-07-06', repos: [baselineEntry('o/a')] },
+      ],
+    };
+    const result = applyMeasurements(history, [measurement('o/a', 72)], '2026-07-06');
+    expect(result.entries[0].repos[0].status).toBe('no-coverage');
+    expect(result.entries[1].repos[0].status).toBe('collected');
+  });
+});

--- a/scripts/central-coverage.ts
+++ b/scripts/central-coverage.ts
@@ -1,0 +1,281 @@
+/**
+ * central-coverage.ts
+ *
+ * Measures real test coverage for the managed repos, centrally — same
+ * architecture as central-scan: runs from the public Factory repo (free
+ * Actions minutes), clones each node-stack repo that has vitest tests,
+ * installs its dependencies and runs `vitest run --coverage`.
+ *
+ * Results land in data/coverage-history.json in the exact format
+ * coverage-baseline.ts maintains and quality-score.ts reads — so scores and
+ * the dashboard update with zero further changes. coverage-baseline (daily)
+ * carries the last measured values forward between weekly runs.
+ *
+ * Two phases so the slow measurement never races the hourly crons that
+ * push to master (the workflow resets onto fresh origin/master between them):
+ *   --measure --out FILE   clone + test + write raw measurements
+ *   --apply FILE           merge measurements into data/coverage-history.json
+ *
+ * Usage: pnpm central-coverage -- --measure --out /tmp/m.json
+ *        pnpm central-coverage -- --apply /tmp/m.json
+ *        pnpm central-coverage                      (both, for local runs)
+ */
+
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  rmSync,
+  mkdirSync,
+  appendFileSync,
+} from 'node:fs';
+import { KNOWN_PROJECTS, type ProjectConfig } from '../factory.config.js';
+import { logActivity } from './activity-logger.js';
+import { sh, tmpDir } from './shell-utils.js';
+
+export interface Coverage {
+  lines: number;
+  branches: number;
+  functions: number;
+  statements: number;
+}
+
+export interface CoverageMeasurement {
+  name: string;
+  repo: string;
+  stack: string;
+  testFramework?: string;
+  hasTests: boolean;
+  testFileCount: number;
+  coverage?: Coverage;
+  status: 'collected' | 'no-coverage' | 'error';
+}
+
+interface CoverageHistory {
+  version: number;
+  lastUpdated: string;
+  entries: { date: string; repos: CoverageMeasurement[] }[];
+}
+
+const NODE_STACKS = new Set(['nextjs', 'fastify', 'node', 'astro']);
+const HISTORY_PATH = 'data/coverage-history.json';
+const INSTALL_TIMEOUT_MS = 300_000;
+const TEST_TIMEOUT_MS = 600_000;
+const BUFFER = 64 * 1024 * 1024;
+
+/** Parse a vitest/istanbul coverage-summary.json into our Coverage shape. */
+export const parseCoverageSummary = (json: string): Coverage | null => {
+  try {
+    const data = JSON.parse(json) as { total?: Record<string, { pct?: number }> };
+    const total = data.total;
+    if (!total?.lines) return null;
+    const pct = (k: string): number => Math.round((total[k]?.pct ?? 0) * 100) / 100;
+    return {
+      lines: pct('lines'),
+      branches: pct('branches'),
+      functions: pct('functions'),
+      statements: pct('statements'),
+    };
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Merge measurements into the history: upsert today's entry, measured repos
+ * win over whatever the daily baseline wrote, unmeasured repos keep their
+ * existing entry for the day.
+ */
+export const applyMeasurements = (
+  history: CoverageHistory,
+  measurements: CoverageMeasurement[],
+  date: string
+): CoverageHistory => {
+  const entries = [...history.entries];
+  const idx = entries.findIndex((e) => e.date === date);
+  const existingRepos = idx >= 0 ? entries[idx].repos : [];
+
+  const measured = new Map(measurements.map((m) => [m.repo, m]));
+  const merged: CoverageMeasurement[] = existingRepos.map((r) => measured.get(r.repo) ?? r);
+  for (const m of measurements) {
+    if (!merged.some((r) => r.repo === m.repo)) merged.push(m);
+  }
+
+  const entry = { date, repos: merged };
+  if (idx >= 0) entries[idx] = entry;
+  else entries.push(entry);
+
+  return { ...history, lastUpdated: new Date().toISOString(), entries };
+};
+
+const detectPackageManager = (dir: string): 'pnpm' | 'yarn' | 'npm' => {
+  if (existsSync(`${dir}/pnpm-lock.yaml`)) return 'pnpm';
+  if (existsSync(`${dir}/yarn.lock`)) return 'yarn';
+  return 'npm';
+};
+
+const countTestFiles = (dir: string): number => {
+  const out = sh(
+    `find . -type f \\( -name "*.test.*" -o -name "*.spec.*" \\) -not -path "*/node_modules/*" | wc -l`,
+    { cwd: dir }
+  );
+  return parseInt(out || '0', 10);
+};
+
+const measureRepo = (project: ProjectConfig): CoverageMeasurement => {
+  const base: CoverageMeasurement = {
+    name: project.name,
+    repo: project.repo,
+    stack: project.stack,
+    hasTests: false,
+    testFileCount: 0,
+    status: 'no-coverage',
+  };
+
+  const dir = `${tmpDir}/central-coverage/${project.name}`;
+  rmSync(dir, { recursive: true, force: true });
+  mkdirSync(dir, { recursive: true });
+  const cloned = sh(`gh repo clone ${project.repo} "${dir}" -- --depth 1 2>&1 && echo OK`, {
+    timeout: 300_000,
+    maxBuffer: BUFFER,
+    fallbackOnError: 'stdout',
+  }).includes('OK');
+  if (!cloned) return { ...base, status: 'error' };
+
+  try {
+    if (!existsSync(`${dir}/package.json`)) return base;
+    const pkg = JSON.parse(readFileSync(`${dir}/package.json`, 'utf-8')) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+    const hasVitest =
+      Boolean(deps['vitest']) ||
+      existsSync(`${dir}/vitest.config.ts`) ||
+      existsSync(`${dir}/vitest.config.mts`) ||
+      existsSync(`${dir}/vitest.config.js`);
+    const testFileCount = countTestFiles(dir);
+    base.testFileCount = testFileCount;
+    base.hasTests = testFileCount > 0;
+    if (!hasVitest || !base.hasTests) return base; // jest & co: not supported yet
+    base.testFramework = 'vitest';
+
+    const pm = detectPackageManager(dir);
+    const installCmd =
+      pm === 'pnpm'
+        ? 'pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile'
+        : pm === 'yarn'
+          ? 'yarn install --frozen-lockfile || yarn install'
+          : existsSync(`${dir}/package-lock.json`)
+            ? 'npm ci || npm install'
+            : 'npm install';
+    const installed = sh(`${installCmd} > /dev/null 2>&1 && echo OK`, {
+      cwd: dir,
+      timeout: INSTALL_TIMEOUT_MS,
+      maxBuffer: BUFFER,
+      fallbackOnError: 'stdout',
+    }).includes('OK');
+    if (!installed) return { ...base, status: 'error' };
+
+    // The clone is throwaway — adding the coverage provider without saving is fine
+    if (!deps['@vitest/coverage-v8']) {
+      const addCmd =
+        pm === 'pnpm'
+          ? 'pnpm add -D @vitest/coverage-v8'
+          : pm === 'yarn'
+            ? 'yarn add -D @vitest/coverage-v8'
+            : 'npm i -D @vitest/coverage-v8';
+      sh(`${addCmd} > /dev/null 2>&1`, {
+        cwd: dir,
+        timeout: INSTALL_TIMEOUT_MS,
+        maxBuffer: BUFFER,
+        fallbackOnError: 'stdout',
+      });
+    }
+
+    sh(
+      `npx vitest run --coverage --coverage.reporter=json-summary --coverage.reportsDirectory=.central-coverage --reporter=dot > /dev/null 2>&1`,
+      { cwd: dir, timeout: TEST_TIMEOUT_MS, maxBuffer: BUFFER, fallbackOnError: 'stdout' }
+    );
+
+    const summaryPath = `${dir}/.central-coverage/coverage-summary.json`;
+    if (!existsSync(summaryPath)) return { ...base, status: 'error' };
+    const coverage = parseCoverageSummary(readFileSync(summaryPath, 'utf-8'));
+    if (!coverage) return { ...base, status: 'error' };
+    return { ...base, coverage, status: 'collected' };
+  } catch {
+    return { ...base, status: 'error' };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+};
+
+const loadHistory = (): CoverageHistory => {
+  if (!existsSync(HISTORY_PATH)) {
+    return { version: 1, lastUpdated: new Date().toISOString(), entries: [] };
+  }
+  try {
+    return JSON.parse(readFileSync(HISTORY_PATH, 'utf-8')) as CoverageHistory;
+  } catch {
+    return { version: 1, lastUpdated: new Date().toISOString(), entries: [] };
+  }
+};
+
+const measure = (outPath: string): void => {
+  const targets = KNOWN_PROJECTS.filter((p) => NODE_STACKS.has(p.stack));
+  console.log(`Measuring coverage for ${targets.length} node-stack repo(s)...\n`);
+  const results: CoverageMeasurement[] = [];
+  for (const project of targets) {
+    process.stdout.write(`${project.name} ... `);
+    const m = measureRepo(project);
+    results.push(m);
+    console.log(m.status === 'collected' ? `${m.coverage?.lines}% lines` : m.status);
+  }
+  writeFileSync(outPath, JSON.stringify(results, null, 2));
+  const collected = results.filter((r) => r.status === 'collected');
+  console.log(`\n${collected.length}/${results.length} repos measured → ${outPath}`);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    let md = `## Central Coverage\n\n| Repo | Lines | Status |\n|------|-------|--------|\n`;
+    for (const r of results) {
+      md += `| ${r.name} | ${r.coverage ? `${r.coverage.lines}%` : '—'} | ${r.status} |\n`;
+    }
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, md);
+  }
+};
+
+const apply = (inPath: string): void => {
+  const measurements = JSON.parse(readFileSync(inPath, 'utf-8')) as CoverageMeasurement[];
+  const date = new Date().toISOString().split('T')[0];
+  const history = applyMeasurements(loadHistory(), measurements, date);
+  writeFileSync(HISTORY_PATH, JSON.stringify(history, null, 2));
+  const collected = measurements.filter((m) => m.status === 'collected').length;
+  console.log(`coverage-history.json updated (${collected} repos with fresh coverage)`);
+  logActivity(
+    'central-coverage',
+    'coverage-measured',
+    `${collected}/${measurements.length} repos measured`,
+    collected > 0 ? 'success' : 'warning'
+  );
+};
+
+const main = (): void => {
+  const args = process.argv.slice(2);
+  const outIdx = args.indexOf('--out');
+  const outPath =
+    outIdx >= 0 && args[outIdx + 1] ? args[outIdx + 1] : '/tmp/coverage-measurements.json';
+  const applyIdx = args.indexOf('--apply');
+
+  if (args.includes('--measure')) {
+    measure(outPath);
+  } else if (applyIdx >= 0) {
+    apply(args[applyIdx + 1] ?? outPath);
+  } else {
+    measure(outPath);
+    apply(outPath);
+  }
+};
+
+const isDirectRun =
+  !process.env.VITEST && process.argv[1]?.replace(/\\/g, '/').endsWith('central-coverage.ts');
+if (isDirectRun) main();

--- a/scripts/coverage-baseline.ts
+++ b/scripts/coverage-baseline.ts
@@ -148,8 +148,42 @@ const fetchCoverageArtifact = (repo: string): Coverage | undefined => {
   }
 };
 
+/**
+ * Most recent measured coverage for a repo (e.g. from the weekly
+ * central-coverage run), looking back at most maxAgeDays.
+ */
+const findLastCollected = (
+  history: CoverageHistory,
+  repo: string,
+  maxAgeDays = 14
+): Coverage | undefined => {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - maxAgeDays);
+  const cutoffStr = cutoff.toISOString().split('T')[0];
+  for (let i = history.entries.length - 1; i >= 0; i--) {
+    const entry = history.entries[i];
+    if (entry.date < cutoffStr) break;
+    const found = entry.repos.find((r) => r.repo === repo);
+    if (found?.status === 'collected' && found.coverage) return found.coverage;
+  }
+  return undefined;
+};
+
+const loadHistoryForCarryForward = (): CoverageHistory => {
+  const historyPath = 'data/coverage-history.json';
+  if (!existsSync(historyPath)) {
+    return { version: 1, lastUpdated: '', entries: [] };
+  }
+  try {
+    return JSON.parse(readFileSync(historyPath, 'utf-8')) as CoverageHistory;
+  } catch {
+    return { version: 1, lastUpdated: '', entries: [] };
+  }
+};
+
 const collectCoverageData = (): CoverageEntry[] => {
   const entries: CoverageEntry[] = [];
+  const history = loadHistoryForCarryForward();
 
   for (const project of KNOWN_PROJECTS) {
     if (project.stack === 'unknown') continue;
@@ -181,6 +215,17 @@ const collectCoverageData = (): CoverageEntry[] => {
       }
     } else if (!hasTests) {
       console.log(`  No tests detected`);
+    }
+
+    // Carry the last measured value forward (weekly central-coverage run)
+    // instead of erasing it with no-coverage between measurements
+    if (entry.status === 'no-coverage' && hasTests) {
+      const carried = findLastCollected(history, project.repo);
+      if (carried) {
+        entry.coverage = carried;
+        entry.status = 'collected';
+        console.log(`  Carried forward: ${carried.lines}% lines (central-coverage)`);
+      }
     }
 
     entries.push(entry);


### PR DESCRIPTION
Débloque la chaîne de couverture : `quality-score` lisait `coverage-history.json`, `coverage-baseline` (quotidien) cherchait des artifacts CI, mais **aucune CI ne mesurait jamais la couverture** → `no-coverage` partout malgré des repos à centaines de tests.

## Ce que fait cette PR

- **`central-coverage.ts` + workflow hebdo (dimanche 4h UTC)** : même architecture que le scan sécurité — clone chaque repo node/vitest, installe ses dépendances, exécute `vitest run --coverage` (en ajoutant `@vitest/coverage-v8` au clone jetable si absent), et fusionne les résultats dans `data/coverage-history.json` **au format existant** → le quality score (15 pts si ≥ 60 %) et le dashboard se mettent à jour sans autre changement.
- **Conception en deux phases** (`--measure` puis `--apply` après reset sur origin/master frais) pour que la mesure longue (~30-60 min) ne rentre jamais en course avec les crons horaires — la leçon du run 5 du scan.
- **`coverage-baseline` reporte désormais la dernière mesure connue** (fenêtre 14 jours) au lieu de l'écraser chaque nuit avec `no-coverage`.
- Flags vitest validés de bout en bout contre ce repo même (7,61 % de lignes — la Factory se mesure elle-même 😄).

879 tests verts (dont 6 nouveaux).

Après merge : premier run dimanche 4h, ou immédiat via Actions → **Central Coverage** → Run workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_