### PR TITLE
feat: registre unifié de posture sécurité (gestion des vulnérabilités)

### DIFF
--- a/.github/workflows/dashboard-build.yml
+++ b/.github/workflows/dashboard-build.yml
@@ -61,6 +61,10 @@ jobs:
           GH_TOKEN: ${{ secrets.FACTORY_PAT }}
         continue-on-error: true
 
+      - name: Security registry (unified findings)
+        run: pnpm security-registry
+        continue-on-error: true
+
       - name: Template drift detection
         run: pnpm template-drift
         env:

--- a/data/security-registry-history.json
+++ b/data/security-registry-history.json
@@ -1,0 +1,17 @@
+{
+  "snapshots": [
+    {
+      "date": "2026-07-06",
+      "avgScorecard": 5.8,
+      "totalRisk": 2590,
+      "reposWithSecrets": 6,
+      "gradeDistribution": {
+        "A": 0,
+        "B": 0,
+        "C": 7,
+        "D": 7,
+        "F": 11
+      }
+    }
+  ]
+}

--- a/data/security-registry.json
+++ b/data/security-registry.json
@@ -1,0 +1,445 @@
+{
+  "date": "2026-07-06",
+  "repos": [
+    {
+      "name": "Lecteur_Magic",
+      "repo": "thonyAGP/lecteur-magic",
+      "risk": 325,
+      "scorecard": 1,
+      "grade": "F",
+      "secrets": 4,
+      "sastErrors": 7,
+      "criticalDeps": 2,
+      "highDeps": 46,
+      "duplicationPct": 41.71,
+      "coveragePct": null,
+      "reasons": [
+        "4 secret(s) exposé(s)",
+        "2 dépendance(s) CRITICAL",
+        "7 erreur(s) SAST",
+        "duplication 41.71%"
+      ]
+    },
+    {
+      "name": "magic-migration",
+      "repo": "thonyAGP/magic-migration",
+      "risk": 325,
+      "scorecard": 1,
+      "grade": "F",
+      "secrets": 4,
+      "sastErrors": 7,
+      "criticalDeps": 2,
+      "highDeps": 46,
+      "duplicationPct": 41.71,
+      "coveragePct": null,
+      "reasons": [
+        "4 secret(s) exposé(s)",
+        "2 dépendance(s) CRITICAL",
+        "7 erreur(s) SAST",
+        "duplication 41.71%"
+      ]
+    },
+    {
+      "name": "ClubMedRoomAssignment",
+      "repo": "thonyAGP/ClubMedRoomAssignment",
+      "risk": 315,
+      "scorecard": 5,
+      "grade": "F",
+      "secrets": 0,
+      "sastErrors": 3,
+      "criticalDeps": 6,
+      "highDeps": 48,
+      "duplicationPct": 3.08,
+      "coveragePct": null,
+      "reasons": [
+        "6 dépendance(s) CRITICAL",
+        "3 erreur(s) SAST",
+        "duplication 3.08%"
+      ]
+    },
+    {
+      "name": "Email_Assistant",
+      "repo": "thonyAGP/Email_Assistant",
+      "risk": 300,
+      "scorecard": 1,
+      "grade": "F",
+      "secrets": 1,
+      "sastErrors": 4,
+      "criticalDeps": 3,
+      "highDeps": 48,
+      "duplicationPct": 16.8,
+      "coveragePct": null,
+      "reasons": [
+        "1 secret(s) exposé(s)",
+        "3 dépendance(s) CRITICAL",
+        "4 erreur(s) SAST",
+        "duplication 16.8%"
+      ]
+    },
+    {
+      "name": "ClaudePilot",
+      "repo": "thonyAGP/ClaudePilot",
+      "risk": 205,
+      "scorecard": 5,
+      "grade": "F",
+      "secrets": 0,
+      "sastErrors": 2,
+      "criticalDeps": 1,
+      "highDeps": 37,
+      "duplicationPct": 10.22,
+      "coveragePct": null,
+      "reasons": [
+        "1 dépendance(s) CRITICAL",
+        "2 erreur(s) SAST",
+        "duplication 10.22%"
+      ]
+    },
+    {
+      "name": "Zentra",
+      "repo": "thonyAGP/zentra",
+      "risk": 155,
+      "scorecard": 7,
+      "grade": "F",
+      "secrets": 0,
+      "sastErrors": 6,
+      "criticalDeps": 0,
+      "highDeps": 25,
+      "duplicationPct": 4.95,
+      "coveragePct": null,
+      "reasons": [
+        "6 erreur(s) SAST",
+        "duplication 4.95%"
+      ]
+    },
+    {
+      "name": "Site_Au-marais",
+      "repo": "thonyAGP/au-marais",
+      "risk": 150,
+      "scorecard": 1,
+      "grade": "F",
+      "secrets": 2,
+      "sastErrors": 5,
+      "criticalDeps": 1,
+      "highDeps": 19,
+      "duplicationPct": 11.05,
+      "coveragePct": null,
+      "reasons": [
+        "2 secret(s) exposé(s)",
+        "1 dépendance(s) CRITICAL",
+        "5 erreur(s) SAST",
+        "duplication 11.05%"
+      ]
+    },
+    {
+      "name": "LB2I-Fiscal-Manager",
+      "repo": "thonyAGP/LB2I-Fiscal-Manager",
+      "risk": 120,
+      "scorecard": 1,
+      "grade": "F",
+      "secrets": 1,
+      "sastErrors": 9,
+      "criticalDeps": 1,
+      "highDeps": 11,
+      "duplicationPct": 7.98,
+      "coveragePct": null,
+      "reasons": [
+        "1 secret(s) exposé(s)",
+        "1 dépendance(s) CRITICAL",
+        "9 erreur(s) SAST",
+        "duplication 7.98%"
+      ]
+    },
+    {
+      "name": "Livret_accueil_Au-Marais",
+      "repo": "thonyAGP/livret-au-marais",
+      "risk": 80,
+      "scorecard": 4,
+      "grade": "F",
+      "secrets": 2,
+      "sastErrors": 4,
+      "criticalDeps": 0,
+      "highDeps": 8,
+      "duplicationPct": 2.32,
+      "coveragePct": null,
+      "reasons": [
+        "2 secret(s) exposé(s)",
+        "4 erreur(s) SAST"
+      ]
+    },
+    {
+      "name": "test_codingmenace",
+      "repo": "thonyAGP/test_codingmenace",
+      "risk": 80,
+      "scorecard": 6,
+      "grade": "F",
+      "secrets": 0,
+      "sastErrors": 4,
+      "criticalDeps": 1,
+      "highDeps": 10,
+      "duplicationPct": 1.88,
+      "coveragePct": null,
+      "reasons": [
+        "1 dépendance(s) CRITICAL",
+        "4 erreur(s) SAST"
+      ]
+    },
+    {
+      "name": "MCP_Quota_Claude",
+      "repo": "thonyAGP/MCP_Quota_Claude",
+      "risk": 80,
+      "scorecard": 8,
+      "grade": "F",
+      "secrets": 0,
+      "sastErrors": 3,
+      "criticalDeps": 0,
+      "highDeps": 13,
+      "duplicationPct": 0.68,
+      "coveragePct": null,
+      "reasons": [
+        "3 erreur(s) SAST"
+      ]
+    },
+    {
+      "name": "Site_1970_Plomberie",
+      "repo": "thonyAGP/Site_1970_Plomberie",
+      "risk": 65,
+      "scorecard": 7,
+      "grade": "D",
+      "secrets": 0,
+      "sastErrors": 3,
+      "criticalDeps": 0,
+      "highDeps": 10,
+      "duplicationPct": 8.32,
+      "coveragePct": null,
+      "reasons": [
+        "3 erreur(s) SAST",
+        "duplication 8.32%"
+      ]
+    },
+    {
+      "name": "Site_Greg-Assainissement",
+      "repo": "thonyAGP/Site_Greg-Assainissement",
+      "risk": 65,
+      "scorecard": 8,
+      "grade": "D",
+      "secrets": 0,
+      "sastErrors": 4,
+      "criticalDeps": 0,
+      "highDeps": 9,
+      "duplicationPct": 1.96,
+      "coveragePct": null,
+      "reasons": [
+        "4 erreur(s) SAST"
+      ]
+    },
+    {
+      "name": "Thumbfast_createur_images",
+      "repo": "thonyAGP/Thumbfast",
+      "risk": 60,
+      "scorecard": 8,
+      "grade": "D",
+      "secrets": 0,
+      "sastErrors": 4,
+      "criticalDeps": 0,
+      "highDeps": 8,
+      "duplicationPct": 1.46,
+      "coveragePct": null,
+      "reasons": [
+        "4 erreur(s) SAST"
+      ]
+    },
+    {
+      "name": "analyse-negocio",
+      "repo": "thonyAGP/analyse-negocio",
+      "risk": 55,
+      "scorecard": 5,
+      "grade": "D",
+      "secrets": 0,
+      "sastErrors": 2,
+      "criticalDeps": 1,
+      "highDeps": 7,
+      "duplicationPct": 6.59,
+      "coveragePct": null,
+      "reasons": [
+        "1 dépendance(s) CRITICAL",
+        "2 erreur(s) SAST",
+        "duplication 6.59%"
+      ]
+    },
+    {
+      "name": "Utilitaire_Webapp",
+      "repo": "thonyAGP/Utilitaire_Webapp",
+      "risk": 45,
+      "scorecard": 8,
+      "grade": "D",
+      "secrets": 0,
+      "sastErrors": 3,
+      "criticalDeps": 0,
+      "highDeps": 6,
+      "duplicationPct": 1.71,
+      "coveragePct": null,
+      "reasons": [
+        "3 erreur(s) SAST"
+      ]
+    },
+    {
+      "name": "CasaSync",
+      "repo": "thonyAGP/CasaSync",
+      "risk": 40,
+      "scorecard": 7,
+      "grade": "D",
+      "secrets": 0,
+      "sastErrors": 4,
+      "criticalDeps": 0,
+      "highDeps": 4,
+      "duplicationPct": 3.69,
+      "coveragePct": null,
+      "reasons": [
+        "4 erreur(s) SAST",
+        "duplication 3.69%"
+      ]
+    },
+    {
+      "name": "DevOps-Factory",
+      "repo": "thonyAGP/DevOps-Factory",
+      "risk": 35,
+      "scorecard": 7,
+      "grade": "D",
+      "secrets": 0,
+      "sastErrors": 3,
+      "criticalDeps": 0,
+      "highDeps": 4,
+      "duplicationPct": 31.96,
+      "coveragePct": null,
+      "reasons": [
+        "3 erreur(s) SAST",
+        "duplication 31.96%"
+      ]
+    },
+    {
+      "name": "Statusline",
+      "repo": "thonyAGP/statusline",
+      "risk": 25,
+      "scorecard": 8,
+      "grade": "C",
+      "secrets": 0,
+      "sastErrors": 3,
+      "criticalDeps": 0,
+      "highDeps": 2,
+      "duplicationPct": 1.97,
+      "coveragePct": null,
+      "reasons": [
+        "3 erreur(s) SAST"
+      ]
+    },
+    {
+      "name": "API_Claude",
+      "repo": "thonyAGP/claude-cli-wrapper",
+      "risk": 15,
+      "scorecard": 8,
+      "grade": "C",
+      "secrets": 0,
+      "sastErrors": 3,
+      "criticalDeps": 0,
+      "highDeps": 0,
+      "duplicationPct": 1.62,
+      "coveragePct": null,
+      "reasons": [
+        "3 erreur(s) SAST"
+      ]
+    },
+    {
+      "name": "Site_Soraya",
+      "repo": "thonyAGP/Site-Soraya",
+      "risk": 10,
+      "scorecard": 8,
+      "grade": "C",
+      "secrets": 0,
+      "sastErrors": 2,
+      "criticalDeps": 0,
+      "highDeps": 0,
+      "duplicationPct": 0.99,
+      "coveragePct": null,
+      "reasons": [
+        "2 erreur(s) SAST"
+      ]
+    },
+    {
+      "name": "Benchmark_Claude",
+      "repo": "thonyAGP/Benchmark_Claude",
+      "risk": 10,
+      "scorecard": 8,
+      "grade": "C",
+      "secrets": 0,
+      "sastErrors": 2,
+      "criticalDeps": 0,
+      "highDeps": 0,
+      "duplicationPct": 1.64,
+      "coveragePct": null,
+      "reasons": [
+        "2 erreur(s) SAST"
+      ]
+    },
+    {
+      "name": "RemoteDevDashboard",
+      "repo": "thonyAGP/RemoteDevDashboard",
+      "risk": 10,
+      "scorecard": 8,
+      "grade": "C",
+      "secrets": 0,
+      "sastErrors": 2,
+      "criticalDeps": 0,
+      "highDeps": 0,
+      "duplicationPct": 1.51,
+      "coveragePct": null,
+      "reasons": [
+        "2 erreur(s) SAST"
+      ]
+    },
+    {
+      "name": "Lanceur_Claude",
+      "repo": "thonyAGP/claude-launcher",
+      "risk": 10,
+      "scorecard": 8,
+      "grade": "C",
+      "secrets": 0,
+      "sastErrors": 2,
+      "criticalDeps": 0,
+      "highDeps": 0,
+      "duplicationPct": 1.76,
+      "coveragePct": null,
+      "reasons": [
+        "2 erreur(s) SAST"
+      ]
+    },
+    {
+      "name": "SqlConnectionTest",
+      "repo": "thonyAGP/SqlConnectionTest",
+      "risk": 10,
+      "scorecard": 8,
+      "grade": "C",
+      "secrets": 0,
+      "sastErrors": 2,
+      "criticalDeps": 0,
+      "highDeps": 0,
+      "duplicationPct": 1.23,
+      "coveragePct": null,
+      "reasons": [
+        "2 erreur(s) SAST"
+      ]
+    }
+  ],
+  "summary": {
+    "avgScorecard": 5.8,
+    "totalRisk": 2590,
+    "reposWithSecrets": 6,
+    "reposOverDuplication": 12,
+    "gradeDistribution": {
+      "A": 0,
+      "B": 0,
+      "C": 7,
+      "D": 7,
+      "F": 11
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "central-scan": "tsx scripts/central-scan.ts",
     "renovate-config": "tsx scripts/central-renovate.ts",
     "central-coverage": "tsx scripts/central-coverage.ts",
+    "security-registry": "tsx scripts/security-registry.ts",
     "template-drift": "tsx scripts/template-drift.ts",
     "dora": "tsx scripts/dora-metrics.ts",
     "cost-monitor": "tsx scripts/cost-monitor.ts",

--- a/scripts/activity-logger.ts
+++ b/scripts/activity-logger.ts
@@ -40,7 +40,8 @@ export type ActivitySource =
   | 'auto-generate-tests'
   | 'knowledge-graph'
   | 'central-scan'
-  | 'central-coverage';
+  | 'central-coverage'
+  | 'security-registry';
 
 export interface ActivityEntry {
   timestamp: string;

--- a/scripts/dashboard/html-assembly.ts
+++ b/scripts/dashboard/html-assembly.ts
@@ -5,6 +5,7 @@ import {
   getFactoryStatusSection,
   getSecurityPostureSection,
   getCentralScanSection,
+  getSecurityRegistrySection,
   getCoverageSection,
   getPerformanceSection,
   getDoraSection,
@@ -101,6 +102,8 @@ export const generateHTML = (statuses: ProjectStatus[]): string => {
   ${getFactoryStatusSection()}
 
   ${getSecurityPostureSection(statuses)}
+
+  ${getSecurityRegistrySection()}
 
   ${getCentralScanSection()}
 

--- a/scripts/dashboard/sections/index.ts
+++ b/scripts/dashboard/sections/index.ts
@@ -1,6 +1,7 @@
 export { getFactoryStatusSection } from './factory-status.js';
 export { getSecurityPostureSection } from './security-posture.js';
 export { getCentralScanSection } from './central-scan.js';
+export { getSecurityRegistrySection } from './security-registry.js';
 export { getCoverageSection } from './coverage.js';
 export { getPerformanceSection } from './performance.js';
 export { getDoraSection } from './dora-metrics.js';

--- a/scripts/dashboard/sections/security-registry.ts
+++ b/scripts/dashboard/sections/security-registry.ts
@@ -1,0 +1,92 @@
+import { readFileSync, existsSync } from 'node:fs';
+
+type Grade = 'A' | 'B' | 'C' | 'D' | 'F';
+
+interface RepoRisk {
+  name: string;
+  repo: string;
+  risk: number;
+  scorecard: number;
+  grade: Grade;
+  secrets: number;
+  sastErrors: number;
+  criticalDeps: number;
+  highDeps: number;
+  duplicationPct: number | null;
+  coveragePct: number | null;
+  reasons: string[];
+}
+
+interface SecurityRegistry {
+  date: string;
+  repos: RepoRisk[];
+  summary: {
+    avgScorecard: number;
+    totalRisk: number;
+    reposWithSecrets: number;
+    reposOverDuplication: number;
+    gradeDistribution: Record<Grade, number>;
+  };
+}
+
+const GRADE_COLOR: Record<Grade, string> = {
+  A: '#22c55e',
+  B: '#84cc16',
+  C: '#f59e0b',
+  D: '#f97316',
+  F: '#ef4444',
+};
+
+const gradeBadge = (grade: Grade): string =>
+  `<span class="reg-grade" style="background:${GRADE_COLOR[grade]}">${grade}</span>`;
+
+export const getSecurityRegistrySection = (): string => {
+  const path = 'data/security-registry.json';
+  if (!existsSync(path)) return '';
+
+  let reg: SecurityRegistry;
+  try {
+    reg = JSON.parse(readFileSync(path, 'utf-8')) as SecurityRegistry;
+  } catch {
+    return '';
+  }
+  if (!reg.repos.length) return '';
+
+  const dist = reg.summary.gradeDistribution;
+  const distChips = (['A', 'B', 'C', 'D', 'F'] as Grade[])
+    .filter((g) => dist[g] > 0)
+    .map((g) => `${gradeBadge(g)}&nbsp;${dist[g]}`)
+    .join('&nbsp;&nbsp;');
+
+  // Top 8 by risk — the actionable head of the list, not a 25-row wall
+  const rows = reg.repos
+    .slice(0, 8)
+    .map((r) => {
+      const reasons = r.reasons.length ? r.reasons.join(', ') : '—';
+      return `<tr>
+        <td>${gradeBadge(r.grade)} ${r.name}</td>
+        <td class="reg-risk">${r.risk}</td>
+        <td class="reg-score">${r.scorecard}/10</td>
+        <td class="reg-reasons">${reasons}</td>
+      </tr>`;
+    })
+    .join('\n');
+
+  return `
+  <div class="security-registry">
+    <h2>Security Posture (registre unifié)</h2>
+    <div class="registry-summary">
+      <span><strong>${reg.summary.avgScorecard}/10</strong> scorecard moyen</span>
+      <span><strong>${reg.summary.totalRisk}</strong> points de risque</span>
+      <span><strong>${reg.summary.reposWithSecrets}</strong> repo(s) avec secrets</span>
+      <span class="registry-dist">${distChips}</span>
+      <span class="registry-date">${reg.date}</span>
+    </div>
+    <table class="registry-table">
+      <thead><tr><th>Repo (top risque)</th><th>Risque</th><th>Scorecard</th><th>Raisons</th></tr></thead>
+      <tbody>
+${rows}
+      </tbody>
+    </table>
+  </div>`;
+};

--- a/scripts/dashboard/styles.ts
+++ b/scripts/dashboard/styles.ts
@@ -320,6 +320,26 @@ export const DASHBOARD_CSS = `
     .coverage-pending-list { margin-top: 0.6rem; font-size: 0.78rem; color: #8b949e; }
     .cov-pending { display: inline-block; background: #21262d; border-radius: 4px; padding: 0.1rem 0.4rem; margin: 0.1rem; }
 
+    /* Security Posture Registry */
+    .security-registry {
+      background: #161b22;
+      border: 1px solid #30363d;
+      border-radius: 8px;
+      padding: 1.2rem;
+      margin-bottom: 1.5rem;
+    }
+    .security-registry h2 { color: #ef4444; font-size: 1rem; margin-bottom: 0.8rem; }
+    .registry-summary { display: flex; gap: 1.2rem; flex-wrap: wrap; align-items: center; font-size: 0.85rem; color: #8b949e; margin-bottom: 0.6rem; }
+    .registry-summary strong { color: #e6edf3; }
+    .registry-date { margin-left: auto; font-style: italic; }
+    .reg-grade { display: inline-block; min-width: 1.1rem; text-align: center; padding: 0 0.35rem; border-radius: 4px; color: #0d1117; font-weight: 700; font-size: 0.75rem; }
+    .registry-table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
+    .registry-table th, .registry-table td { padding: 0.3rem 0.6rem; border-bottom: 1px solid #21262d; text-align: left; vertical-align: top; }
+    .registry-table th { color: #8b949e; }
+    .registry-table .reg-risk { color: #ef4444; font-weight: 600; }
+    .registry-table .reg-score { color: #e6edf3; white-space: nowrap; }
+    .registry-table .reg-reasons { color: #8b949e; }
+
     /* Central Security & Duplication Scan */
     .central-scan {
       background: #161b22;

--- a/scripts/security-registry.test.ts
+++ b/scripts/security-registry.test.ts
@@ -1,0 +1,282 @@
+/**
+ * security-registry.test.ts
+ *
+ * Unit tests for the security registry pure functions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  severityWeight,
+  gradeFromRisk,
+  buildRepoRisk,
+  buildRegistry,
+  diffRegistries,
+  type SecurityRegistry,
+} from './security-registry.js';
+
+const scanRepo = (over: Partial<Parameters<typeof buildRepoRisk>[0]> = {}) => ({
+  name: 'X',
+  repo: 'thonyAGP/X',
+  cloned: true,
+  scanners: [],
+  ...over,
+});
+
+describe('severityWeight', () => {
+  it('weights secrets and critical highest', () => {
+    expect(severityWeight('SECRET')).toBe(10);
+    expect(severityWeight('CRITICAL')).toBe(10);
+  });
+  it('weights high/error at 5, medium/warning at 1', () => {
+    expect(severityWeight('HIGH')).toBe(5);
+    expect(severityWeight('ERROR')).toBe(5);
+    expect(severityWeight('WARNING')).toBe(1);
+  });
+  it('excludes duplication from risk points', () => {
+    expect(severityWeight('DUPLICATION')).toBe(0);
+  });
+  it('is case-insensitive and defaults unknown to 1', () => {
+    expect(severityWeight('high')).toBe(5);
+    expect(severityWeight('mystery')).toBe(1);
+  });
+});
+
+describe('gradeFromRisk', () => {
+  it('maps risk bands to grades', () => {
+    expect(gradeFromRisk(0)).toBe('A');
+    expect(gradeFromRisk(5)).toBe('B');
+    expect(gradeFromRisk(20)).toBe('C');
+    expect(gradeFromRisk(50)).toBe('D');
+    expect(gradeFromRisk(100)).toBe('F');
+  });
+});
+
+describe('buildRepoRisk', () => {
+  it('computes weighted risk from secrets, SAST errors and vulnerable deps', () => {
+    const scan = scanRepo({
+      scanners: [
+        {
+          scanner: 'gitleaks',
+          status: 'findings',
+          findings: 2,
+          bySeverity: { SECRET: 2 },
+          top: [],
+        },
+        {
+          scanner: 'semgrep',
+          status: 'findings',
+          findings: 3,
+          bySeverity: { ERROR: 1, WARNING: 2 },
+          top: [],
+        },
+        {
+          scanner: 'trivy',
+          status: 'findings',
+          findings: 4,
+          bySeverity: { CRITICAL: 1, HIGH: 3 },
+          top: [],
+        },
+        {
+          scanner: 'jscpd',
+          status: 'findings',
+          findings: 5,
+          bySeverity: { DUPLICATION: 5 },
+          top: [],
+          metrics: { duplicationPct: 12 },
+        },
+      ],
+    });
+    const r = buildRepoRisk(scan, 40, 70);
+    // 2*10 (secrets) + 1*5 (ERROR) + 1*10 (CRITICAL) + 3*5 (HIGH) = 50
+    expect(r.risk).toBe(50);
+    expect(r.grade).toBe('D');
+    expect(r.secrets).toBe(2);
+    expect(r.criticalDeps).toBe(1);
+    expect(r.highDeps).toBe(3);
+    expect(r.duplicationPct).toBe(12);
+    expect(r.coveragePct).toBe(40);
+  });
+
+  it('does not count WARNING/duplication toward risk', () => {
+    const scan = scanRepo({
+      scanners: [
+        {
+          scanner: 'semgrep',
+          status: 'findings',
+          findings: 5,
+          bySeverity: { WARNING: 5 },
+          top: [],
+        },
+        {
+          scanner: 'jscpd',
+          status: 'findings',
+          findings: 9,
+          bySeverity: { DUPLICATION: 9 },
+          top: [],
+          metrics: { duplicationPct: 20 },
+        },
+      ],
+    });
+    expect(buildRepoRisk(scan, null, null).risk).toBe(0);
+  });
+
+  it('produces a perfect scorecard for a clean repo', () => {
+    const scan = scanRepo({
+      scanners: [
+        { scanner: 'gitleaks', status: 'clean', findings: 0, bySeverity: {}, top: [] },
+        { scanner: 'semgrep', status: 'clean', findings: 0, bySeverity: {}, top: [] },
+        { scanner: 'trivy', status: 'clean', findings: 0, bySeverity: {}, top: [] },
+        {
+          scanner: 'jscpd',
+          status: 'clean',
+          findings: 0,
+          bySeverity: {},
+          top: [],
+          metrics: { duplicationPct: 1 },
+        },
+      ],
+    });
+    const r = buildRepoRisk(scan, 85, 90);
+    expect(r.scorecard).toBe(10);
+    expect(r.grade).toBe('A');
+    expect(r.reasons).toEqual([]);
+  });
+
+  it('deducts scorecard points with explanatory reasons', () => {
+    const scan = scanRepo({
+      scanners: [
+        {
+          scanner: 'gitleaks',
+          status: 'findings',
+          findings: 1,
+          bySeverity: { SECRET: 1 },
+          top: [],
+        },
+        { scanner: 'trivy', status: 'findings', findings: 1, bySeverity: { CRITICAL: 1 }, top: [] },
+        {
+          scanner: 'jscpd',
+          status: 'findings',
+          findings: 1,
+          bySeverity: { DUPLICATION: 1 },
+          top: [],
+          metrics: { duplicationPct: 8 },
+        },
+      ],
+    });
+    const r = buildRepoRisk(scan, 30, 50);
+    // 10 - 4 (secret) - 2 (critical) - 1 (dup) - 1 (coverage) = 2
+    expect(r.scorecard).toBe(2);
+    expect(r.reasons).toHaveLength(4);
+    expect(r.reasons.some((x) => x.includes('secret'))).toBe(true);
+    expect(r.reasons.some((x) => x.includes('couverture'))).toBe(true);
+  });
+
+  it('floors the scorecard at zero when every weakness applies', () => {
+    const scan = scanRepo({
+      scanners: [
+        {
+          scanner: 'gitleaks',
+          status: 'findings',
+          findings: 9,
+          bySeverity: { SECRET: 9 },
+          top: [],
+        },
+        { scanner: 'semgrep', status: 'findings', findings: 9, bySeverity: { ERROR: 9 }, top: [] },
+        { scanner: 'trivy', status: 'findings', findings: 9, bySeverity: { CRITICAL: 9 }, top: [] },
+        {
+          scanner: 'jscpd',
+          status: 'findings',
+          findings: 9,
+          bySeverity: { DUPLICATION: 9 },
+          top: [],
+          metrics: { duplicationPct: 40 },
+        },
+      ],
+    });
+    // 10 - 4 - 2 - 2 - 1 (dup) - 1 (coverage) = 0, and never negative
+    expect(buildRepoRisk(scan, 0, 0).scorecard).toBe(0);
+  });
+});
+
+describe('buildRegistry', () => {
+  const scan = {
+    date: '2026-07-06',
+    repos: [
+      scanRepo({
+        name: 'Risky',
+        repo: 'o/risky',
+        scanners: [
+          {
+            scanner: 'gitleaks',
+            status: 'findings',
+            findings: 3,
+            bySeverity: { SECRET: 3 },
+            top: [],
+          },
+        ],
+      }),
+      scanRepo({ name: 'Clean', repo: 'o/clean', scanners: [] }),
+      scanRepo({ name: 'Skipped', repo: 'o/skipped', cloned: false, scanners: [] }),
+    ],
+  };
+
+  it('excludes repos that failed to clone and sorts by risk', () => {
+    const reg = buildRegistry(scan, new Map(), new Map());
+    expect(reg.repos.map((r) => r.name)).toEqual(['Risky', 'Clean']);
+    expect(reg.repos[0].risk).toBeGreaterThan(reg.repos[1].risk);
+  });
+
+  it('summarizes fleet posture', () => {
+    const reg = buildRegistry(scan, new Map(), new Map());
+    expect(reg.summary.reposWithSecrets).toBe(1);
+    expect(reg.summary.gradeDistribution.A).toBe(1); // Clean
+    expect(reg.summary.totalRisk).toBe(30);
+    expect(reg.summary.avgScorecard).toBeLessThan(10);
+  });
+});
+
+describe('diffRegistries', () => {
+  const reg = (repo: string, secrets: number, criticalDeps: number): SecurityRegistry => ({
+    date: 'd',
+    repos: [
+      {
+        name: repo,
+        repo,
+        risk: 0,
+        scorecard: 10,
+        grade: 'A',
+        secrets,
+        sastErrors: 0,
+        criticalDeps,
+        highDeps: 0,
+        duplicationPct: null,
+        coveragePct: null,
+        reasons: [],
+      },
+    ],
+    summary: {
+      avgScorecard: 10,
+      totalRisk: 0,
+      reposWithSecrets: 0,
+      reposOverDuplication: 0,
+      gradeDistribution: { A: 1, B: 0, C: 0, D: 0, F: 0 },
+    },
+  });
+
+  it('returns no deltas without a previous registry', () => {
+    expect(diffRegistries(null, reg('o/a', 1, 0))).toEqual([]);
+  });
+
+  it('flags newly introduced and resolved findings', () => {
+    const deltas = diffRegistries(reg('o/a', 0, 2), reg('o/a', 3, 0));
+    expect(deltas.find((d) => d.metric === 'secrets')?.direction).toBe('new');
+    expect(deltas.find((d) => d.metric === 'criticalDeps')?.direction).toBe('resolved');
+  });
+
+  it('distinguishes worse from better on non-zero changes', () => {
+    const deltas = diffRegistries(reg('o/a', 2, 0), reg('o/a', 5, 0));
+    expect(deltas[0].direction).toBe('worse');
+    const deltas2 = diffRegistries(reg('o/a', 5, 0), reg('o/a', 2, 0));
+    expect(deltas2[0].direction).toBe('better');
+  });
+});

--- a/scripts/security-registry.ts
+++ b/scripts/security-registry.ts
@@ -1,0 +1,347 @@
+/**
+ * security-registry.ts
+ *
+ * Single source of truth for the fleet's security & quality posture.
+ * Aggregates the findings the Factory already produces — central-scan
+ * (secrets / SAST / deps / duplication), coverage, quality score — into one
+ * deduplicated, time-tracked registry with a risk score and an OpenSSF-style
+ * grade per repo, plus fleet deltas (new / resolved / regressed).
+ *
+ * Pure functions do all the computation (fully unit-tested); main() only does
+ * IO. Defensive throughout: missing or malformed inputs degrade to empty
+ * rather than throwing, so a partial data set never breaks the dashboard.
+ *
+ * Reads:  data/central-scan-latest.json, data/coverage-history.json,
+ *         dashboard/quality-scores.json, data/security-registry.json (prior)
+ * Writes: data/security-registry.json (current), data/security-registry-history.json
+ *
+ * Run: pnpm security-registry
+ * Cron: daily via dashboard-build.yml (after central-scan / coverage)
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { logActivity } from './activity-logger.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Grade = 'A' | 'B' | 'C' | 'D' | 'F';
+
+export interface RepoRisk {
+  name: string;
+  repo: string;
+  /** Weighted risk points (higher = worse) */
+  risk: number;
+  /** OpenSSF-style posture score, 0 (worst) – 10 (best) */
+  scorecard: number;
+  grade: Grade;
+  secrets: number;
+  sastErrors: number;
+  criticalDeps: number;
+  highDeps: number;
+  duplicationPct: number | null;
+  coveragePct: number | null;
+  /** Human-readable reasons the scorecard was reduced */
+  reasons: string[];
+}
+
+export interface SecurityRegistry {
+  date: string;
+  repos: RepoRisk[];
+  summary: {
+    avgScorecard: number;
+    totalRisk: number;
+    reposWithSecrets: number;
+    reposOverDuplication: number;
+    gradeDistribution: Record<Grade, number>;
+  };
+}
+
+export interface RegistryDelta {
+  repo: string;
+  metric: string;
+  from: number;
+  to: number;
+  direction: 'new' | 'resolved' | 'worse' | 'better';
+}
+
+// Scanner inputs (shape of committed central-scan-latest.json — counts only)
+interface ScanScanner {
+  scanner: string;
+  status: string;
+  findings: number;
+  bySeverity: Record<string, number>;
+  metrics?: Record<string, number>;
+}
+interface ScanRepo {
+  name: string;
+  repo: string;
+  cloned: boolean;
+  scanners: ScanScanner[];
+}
+interface CentralScan {
+  date: string;
+  repos: ScanRepo[];
+}
+interface CoverageHistory {
+  entries: {
+    date: string;
+    repos: { repo: string; status: string; coverage?: { lines: number } }[];
+  }[];
+}
+interface QualityScores {
+  scores: { repo: string; score: number }[];
+}
+
+// ---------------------------------------------------------------------------
+// Pure scoring functions
+// ---------------------------------------------------------------------------
+
+/** Weight of one finding by its reported severity/kind. */
+export const severityWeight = (severity: string): number => {
+  switch (severity.toUpperCase()) {
+    case 'SECRET':
+    case 'CRITICAL':
+      return 10;
+    case 'HIGH':
+    case 'ERROR':
+      return 5;
+    case 'MEDIUM':
+    case 'WARNING':
+      return 1;
+    case 'DUPLICATION':
+      return 0; // maintainability, tracked via duplicationPct not risk points
+    default:
+      return 1;
+  }
+};
+
+const DUPLICATION_THRESHOLD_PCT = 3;
+const COVERAGE_THRESHOLD_PCT = 60;
+
+export const gradeFromRisk = (risk: number): Grade => {
+  if (risk === 0) return 'A';
+  if (risk < 10) return 'B';
+  if (risk < 30) return 'C';
+  if (risk < 75) return 'D';
+  return 'F';
+};
+
+const findScanner = (repo: ScanRepo, name: string): ScanScanner | undefined =>
+  repo.scanners.find((s) => s.scanner === name);
+
+const severityCount = (sc: ScanScanner | undefined, sev: string): number =>
+  sc?.status === 'findings' ? (sc.bySeverity[sev] ?? 0) : 0;
+
+/** Build one repo's risk row from its scan entry + coverage + quality. */
+export const buildRepoRisk = (
+  scan: ScanRepo,
+  coveragePct: number | null,
+  _qualityScore: number | null
+): RepoRisk => {
+  const gitleaks = findScanner(scan, 'gitleaks');
+  const semgrep = findScanner(scan, 'semgrep');
+  const trivy = findScanner(scan, 'trivy');
+  const jscpd = findScanner(scan, 'jscpd');
+
+  const secrets = gitleaks?.status === 'findings' ? gitleaks.findings : 0;
+  const sastErrors = severityCount(semgrep, 'ERROR');
+  const criticalDeps = severityCount(trivy, 'CRITICAL');
+  const highDeps = severityCount(trivy, 'HIGH');
+  const duplicationPct =
+    jscpd?.metrics?.duplicationPct !== undefined ? jscpd.metrics.duplicationPct : null;
+
+  // Weighted risk — only security-bearing signals, not raw noise
+  const risk =
+    secrets * severityWeight('SECRET') +
+    sastErrors * severityWeight('ERROR') +
+    criticalDeps * severityWeight('CRITICAL') +
+    highDeps * severityWeight('HIGH');
+
+  // OpenSSF-style scorecard: start at 10, deduct for concrete weaknesses
+  const reasons: string[] = [];
+  let scorecard = 10;
+  if (secrets > 0) {
+    scorecard -= 4;
+    reasons.push(`${secrets} secret(s) exposé(s)`);
+  }
+  if (criticalDeps > 0) {
+    scorecard -= 2;
+    reasons.push(`${criticalDeps} dépendance(s) CRITICAL`);
+  }
+  if (sastErrors > 0) {
+    scorecard -= 2;
+    reasons.push(`${sastErrors} erreur(s) SAST`);
+  }
+  if (duplicationPct !== null && duplicationPct >= DUPLICATION_THRESHOLD_PCT) {
+    scorecard -= 1;
+    reasons.push(`duplication ${duplicationPct}%`);
+  }
+  if (coveragePct !== null && coveragePct < COVERAGE_THRESHOLD_PCT) {
+    scorecard -= 1;
+    reasons.push(`couverture ${coveragePct}%`);
+  }
+  scorecard = Math.max(0, scorecard);
+
+  return {
+    name: scan.name,
+    repo: scan.repo,
+    risk,
+    scorecard,
+    grade: gradeFromRisk(risk),
+    secrets,
+    sastErrors,
+    criticalDeps,
+    highDeps,
+    duplicationPct,
+    coveragePct,
+    reasons,
+  };
+};
+
+export const buildRegistry = (
+  scan: CentralScan,
+  coverageByRepo: Map<string, number>,
+  qualityByRepo: Map<string, number>
+): SecurityRegistry => {
+  const repos = scan.repos
+    .filter((r) => r.cloned)
+    .map((r) =>
+      buildRepoRisk(r, coverageByRepo.get(r.repo) ?? null, qualityByRepo.get(r.repo) ?? null)
+    )
+    .sort((a, b) => b.risk - a.risk || a.scorecard - b.scorecard);
+
+  const gradeDistribution: Record<Grade, number> = { A: 0, B: 0, C: 0, D: 0, F: 0 };
+  for (const r of repos) gradeDistribution[r.grade]++;
+
+  const avgScorecard =
+    repos.length > 0
+      ? Math.round((repos.reduce((s, r) => s + r.scorecard, 0) / repos.length) * 10) / 10
+      : 0;
+
+  return {
+    date: scan.date,
+    repos,
+    summary: {
+      avgScorecard,
+      totalRisk: repos.reduce((s, r) => s + r.risk, 0),
+      reposWithSecrets: repos.filter((r) => r.secrets > 0).length,
+      reposOverDuplication: repos.filter(
+        (r) => r.duplicationPct !== null && r.duplicationPct >= DUPLICATION_THRESHOLD_PCT
+      ).length,
+      gradeDistribution,
+    },
+  };
+};
+
+/** Per-repo, per-metric changes between two registries. */
+export const diffRegistries = (
+  prev: SecurityRegistry | null,
+  curr: SecurityRegistry
+): RegistryDelta[] => {
+  if (!prev) return [];
+  const prevByRepo = new Map(prev.repos.map((r) => [r.repo, r]));
+  const metrics: (keyof RepoRisk)[] = ['secrets', 'sastErrors', 'criticalDeps', 'highDeps'];
+  const deltas: RegistryDelta[] = [];
+
+  for (const r of curr.repos) {
+    const before = prevByRepo.get(r.repo);
+    if (!before) continue;
+    for (const m of metrics) {
+      const from = before[m] as number;
+      const to = r[m] as number;
+      if (from === to) continue;
+      const direction: RegistryDelta['direction'] =
+        from === 0 && to > 0
+          ? 'new'
+          : to === 0 && from > 0
+            ? 'resolved'
+            : to > from
+              ? 'worse'
+              : 'better';
+      deltas.push({ repo: r.name, metric: m, from, to, direction });
+    }
+  }
+  return deltas;
+};
+
+// ---------------------------------------------------------------------------
+// IO helpers (defensive)
+// ---------------------------------------------------------------------------
+
+const readJson = <T>(path: string): T | null => {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
+};
+
+const latestCoverageByRepo = (history: CoverageHistory | null): Map<string, number> => {
+  const map = new Map<string, number>();
+  if (!history?.entries.length) return map;
+  const latest = history.entries[history.entries.length - 1];
+  for (const r of latest.repos) {
+    if (r.status === 'collected' && r.coverage) map.set(r.repo, r.coverage.lines);
+  }
+  return map;
+};
+
+const qualityByRepoMap = (q: QualityScores | null): Map<string, number> => {
+  const map = new Map<string, number>();
+  for (const s of q?.scores ?? []) map.set(s.repo, s.score);
+  return map;
+};
+
+const REGISTRY_PATH = 'data/security-registry.json';
+const HISTORY_PATH = 'data/security-registry-history.json';
+const MAX_HISTORY = 52; // ~one year of weekly snapshots
+
+const main = (): void => {
+  const scan = readJson<CentralScan>('data/central-scan-latest.json');
+  if (!scan) {
+    console.log('No central-scan-latest.json — run the central scan first. Skipping.');
+    return;
+  }
+  const coverage = latestCoverageByRepo(readJson<CoverageHistory>('data/coverage-history.json'));
+  const quality = qualityByRepoMap(readJson<QualityScores>('dashboard/quality-scores.json'));
+  const prev = readJson<SecurityRegistry>(REGISTRY_PATH);
+
+  const registry = buildRegistry(scan, coverage, quality);
+  const deltas = diffRegistries(prev, registry);
+
+  writeFileSync(REGISTRY_PATH, JSON.stringify(registry, null, 2));
+
+  // Append a compact snapshot to the history for trend charts
+  const history = readJson<{ snapshots: unknown[] }>(HISTORY_PATH) ?? { snapshots: [] };
+  history.snapshots.push({
+    date: registry.date,
+    avgScorecard: registry.summary.avgScorecard,
+    totalRisk: registry.summary.totalRisk,
+    reposWithSecrets: registry.summary.reposWithSecrets,
+    gradeDistribution: registry.summary.gradeDistribution,
+  });
+  if (history.snapshots.length > MAX_HISTORY) {
+    history.snapshots = history.snapshots.slice(-MAX_HISTORY);
+  }
+  writeFileSync(HISTORY_PATH, JSON.stringify(history, null, 2));
+
+  const resolved = deltas.filter((d) => d.direction === 'resolved').length;
+  const newOnes = deltas.filter((d) => d.direction === 'new').length;
+  console.log(
+    `Security registry: ${registry.repos.length} repos, avg scorecard ${registry.summary.avgScorecard}/10, ` +
+      `${registry.summary.totalRisk} risk pts, +${newOnes} new / -${resolved} resolved`
+  );
+  logActivity(
+    'security-registry',
+    'registry-updated',
+    `avg ${registry.summary.avgScorecard}/10, ${registry.summary.totalRisk} risk pts, +${newOnes}/-${resolved}`,
+    newOnes > 0 ? 'warning' : 'success'
+  );
+};
+
+const isDirectRun =
+  !process.env.VITEST && process.argv[1]?.replace(/\\/g, '/').endsWith('security-registry.ts');
+if (isDirectRun) main();


### PR DESCRIPTION
Le saut n°1 de la roadmap : la couche d'agrégation qui manquait. Vos findings étaient dispersés dans des issues par repo — désormais une **source de vérité unique, priorisée et suivie dans le temps**.

## Ce que ça fait

`scripts/security-registry.ts` agrège ce que l'usine produit déjà (central-scan : secrets/SAST/deps/duplication + couverture + quality) en :

- **un score de risque par repo** — pondéré par sévérité (secret & CRITICAL = 10, HIGH & ERROR = 5, WARNING = 1) ; la duplication est exclue du risque (traitée comme maintenabilité, pas comme faille)
- **un scorecard 0-10 façon OpenSSF** avec les raisons explicites de chaque déduction
- **synthèse flotte** : scorecard moyen, risque total, distribution des notes A→F
- **deltas** vs le snapshot précédent : nouveau / résolu / aggravé / amélioré
- **historique 52 semaines** pour les tendances

Qualité de construction (votre remarque « bien construite ») : **toute la logique est en fonctions pures, 15 tests unitaires** ; le `main()` ne fait que de l'IO, **défensif** (entrées manquantes/corrompues → dégradation vers vide, jamais d'exception).

## Intégration

- Tourne dans `dashboard-build` après les rapports qui l'alimentent
- Nouvelle section dashboard « Security Posture (registre unifié) » : scorecard moyen, risque total, distribution des notes, top-8 repos par risque avec raisons

## Résultat sur les vraies données d'aujourd'hui

Scorecard moyen **5,8/10**, 2590 points de risque, **11 repos en F**. Tête de liste : Lecteur_Magic et magic-migration (325 pts — 4 secrets + 2 CRITICAL + 7 erreurs SAST chacun), ClubMedRoomAssignment (315), Email_Assistant (300).

894 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_