### PR TITLE
fix: ne plus scanner l'historique gitleaks de la Factory elle-même (timeout redondant)

### DIFF
--- a/scripts/central-scan.ts
+++ b/scripts/central-scan.ts
@@ -411,7 +411,8 @@ const runTrivy = (dir: string): ScannerResult => {
 
 const scanRepo = (
   project: ProjectConfig,
-  available: Record<ScannerName, boolean>
+  available: Record<ScannerName, boolean>,
+  factoryRepo: string
 ): RepoScanResult => {
   const dir = `${tmpDir}/central-scan/${project.name}`;
   rmSync(dir, { recursive: true, force: true });
@@ -441,7 +442,17 @@ const scanRepo = (
     top: [],
   });
 
-  result.scanners.push(available.gitleaks ? runGitleaks(dir) : skipped('gitleaks'));
+  // The Factory's own history is huge (hourly data/*.json commits) and it
+  // already runs a dedicated gitleaks workflow — a full-history gitleaks scan
+  // here reliably times out, so skip it rather than report a perpetual error
+  const gitleaksRedundant = project.repo === factoryRepo;
+  result.scanners.push(
+    gitleaksRedundant
+      ? skipped('gitleaks')
+      : available.gitleaks
+        ? runGitleaks(dir)
+        : skipped('gitleaks')
+  );
   result.scanners.push(available.semgrep ? runSemgrep(dir, project.stack) : skipped('semgrep'));
   result.scanners.push(available.trivy ? runTrivy(dir) : skipped('trivy'));
   result.scanners.push(available.jscpd ? runJscpd(dir) : skipped('jscpd'));
@@ -608,7 +619,7 @@ const main = (): void => {
   const results: RepoScanResult[] = [];
   for (const project of targets) {
     process.stdout.write(`${project.name} ... `);
-    const result = scanRepo(project, available);
+    const result = scanRepo(project, available, factoryRepo);
     results.push(result);
     if (!result.cloned) {
       console.log('clone failed');


### PR DESCRIPTION
Sur le run de scan qui vient de passer (704 findings, rapport enfin propre), **DevOps-Factory était le seul repo encore en ⚠️ sur gitleaks**. Preuve que c'est un timeout et pas un vrai problème : CasaSync, aussi en ⚠️ avant, complète maintenant grâce au timeout de 10 min (et révèle d'ailleurs 13 secrets).

L'historique de la Factory est énorme (commits horaires de `data/*.json`), donc le scan d'historique complet dépasse 10 min. Et c'est **redondant** : la Factory a déjà son propre workflow gitleaks dédié. On le saute donc dans le scan central (semgrep/trivy/jscpd continuent de tourner sur la Factory). C'était la dernière erreur gitleaks du tableau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_