### PR TITLE
feat: dispatcher de remédiation autonome (squelette du saut #3, fail-closed)

### DIFF
--- a/.github/workflows/remediation-dispatch.yml
+++ b/.github/workflows/remediation-dispatch.yml
@@ -1,0 +1,55 @@
+# DevOps-Factory: Remediation Dispatch
+# Reads the security registry and fires a bounded remediation agent at the
+# worst-graded repos (saut #3). Fail-closed: does nothing until
+# REMEDIATION_CONFIG is enabled with an explicit allowlist. Manual dispatch
+# only — no cron until the loop is trusted.
+
+name: Remediation Dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List targets without dispatching agents'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: remediation-dispatch
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.FACTORY_PAT }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Dispatch remediation agents
+        run: |
+          if [ "$DRY_RUN" = "false" ]; then
+            pnpm remediation-dispatch
+          else
+            pnpm remediation-dispatch -- --dry-run
+          fi
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          GH_TOKEN: ${{ secrets.FACTORY_PAT }}

--- a/docs/remediation.md
+++ b/docs/remediation.md
@@ -1,0 +1,47 @@
+# Autonomous Remediation (saut #3)
+
+Le modèle **agent éphémère déclenché par événement**, pas la session persistante.
+La Factory (état durable) sélectionne les repos les plus mal notés dans le
+registre de sécurité (état durable) et lance, pour chacun, un agent de codage
+**court** qui corrige et ouvre une PR — puis meurt. Aucune session résidente.
+
+```
+security-registry.json ──► remediation-dispatch ──► gh workflow run ai-remediation.yml
+   (état durable)              (Factory, quota)         (repo cible, agent éphémère)
+                                                              │
+                                                    lit l'issue central-scan
+                                                    corrige → PR → exit
+```
+
+## Garde-fous (fail-closed)
+
+Rien ne part tant que tout n'est pas explicitement autorisé :
+
+- `REMEDIATION_CONFIG.enabled` = `false` par défaut → le dispatcher est un no-op
+- `enabledRepos` vide par défaut → **allowlist** : seuls les repos listés sont éligibles
+- `minGrade` (`F` par défaut) → seuls les repos assez mal notés qualifient
+- **quota journalier** (`maxPerDay`, 2) → borne le nombre d'agents lancés/jour
+- l'agent cible est lui-même borné : `max_turns`, `allowed_tools`, prompt à
+  périmètre serré (jamais de secrets, jamais de refactor/majeure, tests
+  obligatoires, une seule PR)
+
+La logique de sélection est une **fonction pure testée** (`selectRemediationTargets`).
+
+## Activation (opt-in explicite)
+
+1. Dans chaque repo cible : secret `ANTHROPIC_API_KEY` + le workflow
+   `ai-remediation.yml` (déployé via `redeploy-templates` ou `scan-and-configure`).
+2. Dans `factory.config.ts` → `REMEDIATION_CONFIG` : `enabled: true` et ajouter
+   les repos dans `enabledRepos` (commencez par **un seul**).
+3. Onglet Actions → **Remediation Dispatch** → Run workflow. Laissez
+   `dry_run: true` d'abord pour voir les cibles sélectionnées, puis `false`.
+
+Aucun cron n'est configuré : le dispatch reste manuel tant que la boucle n'est
+pas éprouvée. Le passage à un cron (quotidien) est un changement d'une ligne
+une fois la confiance établie.
+
+## Usage local
+
+```bash
+pnpm remediation-dispatch -- --dry-run   # liste les cibles sans rien lancer
+```

--- a/factory.config.ts
+++ b/factory.config.ts
@@ -489,6 +489,34 @@ export const WEBHOOK_CONFIG: WebhookConfig = {
  */
 export const CENTRAL_RENOVATE_ENABLED = true;
 
+export interface RemediationConfig {
+  /** Master switch. While false the dispatcher is a no-op. */
+  enabled: boolean;
+  /** Only these repos may be remediated (empty = none — opt-in safety). */
+  enabledRepos: string[];
+  /** Repos at or below this grade are eligible (F worst → A best). */
+  minGrade: 'F' | 'D' | 'C';
+  /** Max remediation agents dispatched per day, across the fleet. */
+  maxPerDay: number;
+  /** Target-repo workflow the dispatcher triggers. */
+  workflowFile: string;
+}
+
+/**
+ * Autonomous remediation (saut #3): the dispatcher reads the security
+ * registry and triggers a bounded coding agent on the worst-graded repos.
+ * Disabled and allowlist-empty by default — enabling requires an explicit
+ * opt-in plus ANTHROPIC_API_KEY + the ai-remediation.yml workflow in each
+ * target repo. Guardrails: allowlist, grade gate, daily quota.
+ */
+export const REMEDIATION_CONFIG: RemediationConfig = {
+  enabled: false,
+  enabledRepos: [],
+  minGrade: 'F',
+  maxPerDay: 2,
+  workflowFile: 'ai-remediation.yml',
+};
+
 export const GITHUB_OWNER = 'thonyAGP';
 
 export const DASHBOARD_URL = 'https://thonyagp.github.io/DevOps-Factory/';

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "renovate-config": "tsx scripts/central-renovate.ts",
     "central-coverage": "tsx scripts/central-coverage.ts",
     "security-registry": "tsx scripts/security-registry.ts",
+    "remediation-dispatch": "tsx scripts/remediation-dispatch.ts",
     "template-drift": "tsx scripts/template-drift.ts",
     "dora": "tsx scripts/dora-metrics.ts",
     "cost-monitor": "tsx scripts/cost-monitor.ts",

--- a/scripts/activity-logger.ts
+++ b/scripts/activity-logger.ts
@@ -41,7 +41,8 @@ export type ActivitySource =
   | 'knowledge-graph'
   | 'central-scan'
   | 'central-coverage'
-  | 'security-registry';
+  | 'security-registry'
+  | 'remediation-dispatch';
 
 export interface ActivityEntry {
   timestamp: string;

--- a/scripts/redeploy-templates.ts
+++ b/scripts/redeploy-templates.ts
@@ -40,6 +40,10 @@ const TEMPLATES: Record<string, { file: string; target: string; stacks?: string[
     file: 'templates/dead-code-detection.yml',
     target: '.github/workflows/dead-code-detection.yml',
   },
+  'ai-remediation': {
+    file: 'templates/ai-remediation.yml',
+    target: '.github/workflows/ai-remediation.yml',
+  },
 };
 
 const getRemoteFileContent = (repo: string, path: string): string | null => {

--- a/scripts/remediation-dispatch.test.ts
+++ b/scripts/remediation-dispatch.test.ts
@@ -1,0 +1,74 @@
+/**
+ * remediation-dispatch.test.ts
+ *
+ * Unit tests for the remediation target-selection policy. The guardrails are
+ * the whole point, so they are tested explicitly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { selectRemediationTargets } from './remediation-dispatch.js';
+import type { RemediationConfig } from '../factory.config.js';
+
+type Grade = 'A' | 'B' | 'C' | 'D' | 'F';
+
+const repo = (name: string, grade: Grade, risk: number) => ({
+  name,
+  repo: `thonyAGP/${name}`,
+  risk,
+  grade,
+  reasons: [],
+});
+
+const registry = {
+  date: 'd',
+  repos: [repo('F1', 'F', 300), repo('F2', 'F', 100), repo('D1', 'D', 50), repo('A1', 'A', 0)],
+};
+
+const config = (over: Partial<RemediationConfig> = {}): RemediationConfig => ({
+  enabled: true,
+  enabledRepos: ['thonyAGP/F1', 'thonyAGP/F2', 'thonyAGP/D1'],
+  minGrade: 'F',
+  maxPerDay: 2,
+  workflowFile: 'ai-remediation.yml',
+  ...over,
+});
+
+describe('selectRemediationTargets — guardrails', () => {
+  it('returns nothing when remediation is disabled', () => {
+    expect(selectRemediationTargets(registry, config({ enabled: false }), 5)).toEqual([]);
+  });
+
+  it('returns nothing when the allowlist is empty (opt-in safety)', () => {
+    expect(selectRemediationTargets(registry, config({ enabledRepos: [] }), 5)).toEqual([]);
+  });
+
+  it('never selects a repo outside the allowlist', () => {
+    const cfg = config({ enabledRepos: ['thonyAGP/F1'] });
+    const got = selectRemediationTargets(registry, cfg, 5);
+    expect(got.map((r) => r.name)).toEqual(['F1']);
+  });
+
+  it('respects the grade threshold (F only by default)', () => {
+    const got = selectRemediationTargets(registry, config(), 5);
+    // D1 is allowlisted but grade D < F threshold → excluded
+    expect(got.map((r) => r.name)).toEqual(['F1', 'F2']);
+  });
+
+  it('includes D when the threshold is lowered to D', () => {
+    const got = selectRemediationTargets(registry, config({ minGrade: 'D' }), 5);
+    expect(got.map((r) => r.name)).toContain('D1');
+  });
+
+  it('orders worst-risk first', () => {
+    const got = selectRemediationTargets(registry, config({ minGrade: 'D' }), 5);
+    expect(got.map((r) => r.risk)).toEqual([300, 100, 50]);
+  });
+
+  it('caps at the remaining daily quota', () => {
+    expect(selectRemediationTargets(registry, config(), 1).map((r) => r.name)).toEqual(['F1']);
+  });
+
+  it('returns nothing when the quota is exhausted', () => {
+    expect(selectRemediationTargets(registry, config(), 0)).toEqual([]);
+  });
+});

--- a/scripts/remediation-dispatch.ts
+++ b/scripts/remediation-dispatch.ts
@@ -1,0 +1,167 @@
+/**
+ * remediation-dispatch.ts
+ *
+ * The saut #3 trigger: reads the security registry and dispatches a bounded
+ * coding agent onto the worst-graded repos to fix their central-scan findings.
+ *
+ * This is the event-driven-ephemeral-agent model, NOT a persistent session:
+ * the Factory (durable state) selects targets from the registry (durable
+ * state), fires a short-lived agent per repo via workflow_dispatch, and the
+ * agent dies after opening its PR. No always-on session anywhere.
+ *
+ * Safety is layered and fail-closed:
+ * - REMEDIATION_CONFIG.enabled must be true (default false → no-op)
+ * - only repos in REMEDIATION_CONFIG.enabledRepos are eligible (default empty)
+ * - only repos at/below minGrade qualify
+ * - a fleet-wide daily quota caps dispatches
+ * - --dry-run lists targets without firing
+ *
+ * Usage: pnpm remediation-dispatch [-- --dry-run]
+ * Cron: none by default — manual dispatch until explicitly opted in
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { REMEDIATION_CONFIG, type RemediationConfig } from '../factory.config.js';
+import { logActivity } from './activity-logger.js';
+import { sh } from './shell-utils.js';
+
+type Grade = 'A' | 'B' | 'C' | 'D' | 'F';
+
+interface RepoRisk {
+  name: string;
+  repo: string;
+  risk: number;
+  grade: Grade;
+  reasons: string[];
+}
+interface SecurityRegistry {
+  date: string;
+  repos: RepoRisk[];
+}
+interface Quota {
+  date: string;
+  count: number;
+  maxPerDay: number;
+}
+
+const REGISTRY_PATH = 'data/security-registry.json';
+const QUOTA_PATH = 'data/remediation-quota.json';
+
+const GRADE_RANK: Record<Grade, number> = { A: 0, B: 1, C: 2, D: 3, F: 4 };
+
+/**
+ * Pure target selection — the whole policy in one testable function.
+ * A repo qualifies when: remediation is enabled, it is allowlisted, its grade
+ * is at or below the threshold, and the daily quota still has room. Returned
+ * worst-first, capped at the remaining quota.
+ */
+export const selectRemediationTargets = (
+  registry: SecurityRegistry,
+  config: RemediationConfig,
+  remainingQuota: number
+): RepoRisk[] => {
+  if (!config.enabled || remainingQuota <= 0) return [];
+  const allow = new Set(config.enabledRepos);
+  const threshold = GRADE_RANK[config.minGrade];
+
+  return registry.repos
+    .filter((r) => allow.has(r.repo))
+    .filter((r) => GRADE_RANK[r.grade] >= threshold)
+    .sort((a, b) => b.risk - a.risk)
+    .slice(0, remainingQuota);
+};
+
+const loadRegistry = (): SecurityRegistry | null => {
+  if (!existsSync(REGISTRY_PATH)) return null;
+  try {
+    return JSON.parse(readFileSync(REGISTRY_PATH, 'utf-8')) as SecurityRegistry;
+  } catch {
+    return null;
+  }
+};
+
+const loadQuota = (): Quota => {
+  const today = new Date().toISOString().split('T')[0];
+  if (!existsSync(QUOTA_PATH)) {
+    return { date: today, count: 0, maxPerDay: REMEDIATION_CONFIG.maxPerDay };
+  }
+  try {
+    const q = JSON.parse(readFileSync(QUOTA_PATH, 'utf-8')) as Quota;
+    if (q.date !== today) return { date: today, count: 0, maxPerDay: REMEDIATION_CONFIG.maxPerDay };
+    return q;
+  } catch {
+    return { date: today, count: 0, maxPerDay: REMEDIATION_CONFIG.maxPerDay };
+  }
+};
+
+const saveQuota = (q: Quota): void => writeFileSync(QUOTA_PATH, JSON.stringify(q, null, 2));
+
+/** Fire the bounded agent workflow in a target repo. Returns true on success. */
+const dispatchAgent = (repo: string): boolean => {
+  const out = sh(
+    `gh workflow run ${REMEDIATION_CONFIG.workflowFile} --repo ${repo} 2>&1 && echo DISPATCHED`
+  );
+  return out.includes('DISPATCHED');
+};
+
+const main = (): void => {
+  const dryRun = process.argv.slice(2).includes('--dry-run');
+
+  if (!REMEDIATION_CONFIG.enabled) {
+    console.log('Remediation disabled (REMEDIATION_CONFIG.enabled = false). No-op.');
+    return;
+  }
+
+  const registry = loadRegistry();
+  if (!registry) {
+    console.log('No security-registry.json — run the security registry first. Skipping.');
+    return;
+  }
+
+  const quota = loadQuota();
+  const remaining = quota.maxPerDay - quota.count;
+  const targets = selectRemediationTargets(registry, REMEDIATION_CONFIG, remaining);
+
+  if (targets.length === 0) {
+    console.log(
+      `No eligible targets (allowlist=${REMEDIATION_CONFIG.enabledRepos.length}, ` +
+        `grade≤${REMEDIATION_CONFIG.minGrade}, quota ${quota.count}/${quota.maxPerDay}).`
+    );
+    return;
+  }
+
+  console.log(`${targets.length} target(s) selected (quota ${quota.count}/${quota.maxPerDay}):`);
+  let dispatched = 0;
+  for (const t of targets) {
+    console.log(`  ${t.grade} ${t.name} (risk ${t.risk}) — ${t.reasons.join(', ')}`);
+    if (dryRun) continue;
+    if (dispatchAgent(t.repo)) {
+      dispatched++;
+      quota.count++;
+      saveQuota(quota);
+      logActivity(
+        'remediation-dispatch',
+        'agent-dispatched',
+        `grade ${t.grade}, risk ${t.risk}`,
+        'warning',
+        t.name
+      );
+    } else {
+      console.log(`    [WARN] dispatch failed for ${t.repo} (workflow present + API key set?)`);
+    }
+  }
+
+  if (!dryRun) {
+    console.log(`\nDispatched ${dispatched} remediation agent(s).`);
+    logActivity(
+      'remediation-dispatch',
+      'dispatch-complete',
+      `${dispatched} agent(s) dispatched, quota ${quota.count}/${quota.maxPerDay}`,
+      dispatched > 0 ? 'warning' : 'info'
+    );
+  }
+};
+
+const isDirectRun =
+  !process.env.VITEST && process.argv[1]?.replace(/\\/g, '/').endsWith('remediation-dispatch.ts');
+if (isDirectRun) main();

--- a/templates/ai-remediation.yml
+++ b/templates/ai-remediation.yml
@@ -1,0 +1,71 @@
+# DevOps-Factory: AI Remediation Agent
+# A bounded, ephemeral coding agent that fixes this repo's central-scan
+# findings and opens a PR — then exits. Dispatched by the Factory's
+# remediation-dispatch for repos graded F in the security registry.
+#
+# Requires (per repo): secret ANTHROPIC_API_KEY. The agent is deliberately
+# constrained: it fixes tractable SAST/dep findings, never touches secrets
+# (rotation is manual), never does large refactors or major bumps, always
+# runs tests, and opens exactly one PR for human review.
+
+name: AI Remediation
+
+on:
+  workflow_dispatch:
+    inputs: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+concurrency:
+  group: ai-remediation
+  cancel-in-progress: false
+
+jobs:
+  remediate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run remediation agent
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          direct_prompt: |
+            Tu corriges les problèmes de sécurité et de qualité détectés par le
+            scan centralisé de DevOps-Factory sur ce repository.
+
+            CONTEXTE
+            - Une issue GitHub avec le label `central-scan` liste les findings
+              localisés (fichier:ligne, règle, CVE) : lis-la en premier.
+            - Scanners : gitleaks (secrets), semgrep (SAST OWASP), trivy
+              (dépendances vulnérables), jscpd (duplication).
+
+            À FAIRE
+            1. Corriger les findings Semgrep de sévérité ERROR au correctif
+               clair et local.
+            2. Monter les dépendances vulnérables trivy CRITICAL/HIGH vers la
+               première version corrigée NON-majeure.
+            3. Après chaque correction, lancer les tests et le lint ; ne rien
+               casser. Absence de tests : le signaler.
+
+            INTERDIT
+            - Ne touche PAS aux secrets exposés (rotation manuelle) — signale-les.
+            - Aucun refactor large, aucune montée majeure, aucune modification de
+              logique métier pour faire taire un linter.
+
+            LIVRABLE
+            - UNE seule PR, titre `fix: corrections sécurité & qualité (central-scan)`.
+            - Description : ✅ corrigé / ⏭️ reporté (raison) / 🔴 action humaine
+              requise (secrets, majeures).
+            - Commits conventionnels et atomiques.
+
+            Commence par l'issue `central-scan`, établis un plan priorisé, puis
+            exécute et ouvre la PR.
+          allowed_tools: 'Bash,Edit,Write,Read,Grep,Glob'
+          max_turns: '30'


### PR DESCRIPTION
Le déclencheur concret dont on parlait : l'alternative « agent éphémère event-driven » aux sessions persistantes.

## Le modèle

```
security-registry.json → remediation-dispatch → gh workflow run ai-remediation.yml
   (état durable)          (Factory, quota)          (repo cible, agent éphémère)
                                                            ↓ lit l'issue central-scan
                                                            corrige → 1 PR → exit
```

La Factory sélectionne les repos notés F dans le registre, lance un agent **court** par repo qui corrige les findings et ouvre une PR, puis meurt. **L'état vit dans le durable** (registre, issues `central-scan`, repo), jamais dans une session résidente.

## Garde-fous fail-closed (le cœur du design)

Rien ne part sans opt-in explicite :
- `REMEDIATION_CONFIG.enabled = false` par défaut → dispatcher no-op
- `enabledRepos` vide → **allowlist** par repo
- gate de note (F) + **quota journalier** (2)
- `selectRemediationTargets` = fonction **pure, 8 tests**
- l'agent lui-même borné : `max_turns`, `allowed_tools`, prompt à périmètre serré (jamais de secrets, jamais de refactor/majeure, tests obligatoires, une PR)

## Contenu

- `scripts/remediation-dispatch.ts` (+ tests)
- `templates/ai-remediation.yml` — workflow agent (Claude Code Action) pour les repos cibles
- `.github/workflows/remediation-dispatch.yml` — dispatch manuel, dry-run par défaut
- `factory.config.ts` → `REMEDIATION_CONFIG`, enregistrement redeploy, `docs/remediation.md`

Activation = opt-in explicite (ANTHROPIC_API_KEY par repo + `enabled: true` + allowlist). Aucun cron tant que la boucle n'est pas éprouvée.

902 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_