### PR TITLE
feat: distribution du secret en un coup + token OAuth pour l'agent de remédiation

### DIFF
--- a/docs/remediation.md
+++ b/docs/remediation.md
@@ -27,13 +27,41 @@ Rien ne part tant que tout n'est pas explicitement autorisé :
 
 La logique de sélection est une **fonction pure testée** (`selectRemediationTargets`).
 
+## Le moteur LLM : token d'abonnement (sans clé API)
+
+L'agent tourne via `anthropics/claude-code-action` authentifié par un **token
+OAuth d'abonnement** (`claude_code_oauth_token`) — pas de clé API, donc **aucune
+facturation à l'usage** : la conso passe par le quota de l'abonnement Claude
+(Pro/Max). Le pire cas est un rate-limit, jamais une facture. (TOS : ce token
+n'est autorisé que pour Claude Code / `claude-code-action`, pas pour l'Agent
+SDK.)
+
+Générer le token une fois, avec **ton** compte perso :
+
+```bash
+claude /logout        # si le CLI est logué sur un autre compte
+claude setup-token    # flux OAuth navigateur → copie le sk-ant-oat01-…
+```
+
 ## Activation (opt-in explicite)
 
-1. Dans chaque repo cible : secret `ANTHROPIC_API_KEY` + le workflow
-   `ai-remediation.yml` (déployé via `redeploy-templates` ou `scan-and-configure`).
-2. Dans `factory.config.ts` → `REMEDIATION_CONFIG` : `enabled: true` et ajouter
-   les repos dans `enabledRepos` (commencez par **un seul**).
-3. Onglet Actions → **Remediation Dispatch** → Run workflow. Laissez
+1. **App Claude** : installe-la **une fois** sur _All repositories_
+   (github.com/apps/claude) — elle donne les permissions repo. Pas de répétition
+   par repo.
+2. **Secret sur les repos cibles** : `CLAUDE_CODE_OAUTH_TOKEN`. Plutôt que de
+   cliquer 25 fois, distribue-le en masse (localement, `gh` authentifié) :
+   ```bash
+   export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
+   pnpm distribute-remediation-secret            # tous les repos gérés
+   pnpm distribute-remediation-secret -- --only lecteur-magic   # ou un sous-ensemble
+   ```
+   Le secret est **inerte** tant que le repo n'est pas dans l'allowlist + n'a pas
+   le workflow — le distribuer largement est sans risque.
+3. **Workflow agent** : `ai-remediation.yml` déployé via `redeploy-templates`
+   (ou `scan-and-configure`).
+4. **`factory.config.ts` → `REMEDIATION_CONFIG`** : `enabled: true` + ajouter les
+   repos dans `enabledRepos` (commencez par **un seul**).
+5. Onglet Actions → **Remediation Dispatch** → Run workflow. Laissez
    `dry_run: true` d'abord pour voir les cibles sélectionnées, puis `false`.
 
 Aucun cron n'est configuré : le dispatch reste manuel tant que la boucle n'est

--- a/factory.config.ts
+++ b/factory.config.ts
@@ -506,8 +506,8 @@ export interface RemediationConfig {
  * Autonomous remediation (saut #3): the dispatcher reads the security
  * registry and triggers a bounded coding agent on the worst-graded repos.
  * Disabled and allowlist-empty by default — enabling requires an explicit
- * opt-in plus ANTHROPIC_API_KEY + the ai-remediation.yml workflow in each
- * target repo. Guardrails: allowlist, grade gate, daily quota.
+ * opt-in plus CLAUDE_CODE_OAUTH_TOKEN + the ai-remediation.yml workflow in
+ * each target repo. Guardrails: allowlist, grade gate, daily quota.
  */
 export const REMEDIATION_CONFIG: RemediationConfig = {
   enabled: false,

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "central-coverage": "tsx scripts/central-coverage.ts",
     "security-registry": "tsx scripts/security-registry.ts",
     "remediation-dispatch": "tsx scripts/remediation-dispatch.ts",
+    "distribute-remediation-secret": "tsx scripts/distribute-remediation-secret.ts",
     "template-drift": "tsx scripts/template-drift.ts",
     "dora": "tsx scripts/dora-metrics.ts",
     "cost-monitor": "tsx scripts/cost-monitor.ts",

--- a/scripts/distribute-remediation-secret.test.ts
+++ b/scripts/distribute-remediation-secret.test.ts
@@ -1,0 +1,70 @@
+/**
+ * distribute-remediation-secret.test.ts
+ *
+ * The IO (gh secret set) is not unit-tested, but target selection — which
+ * repos receive the secret — is pure and covered here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { selectSecretTargets } from './distribute-remediation-secret.js';
+import type { ProjectConfig } from '../factory.config.js';
+
+const p = (name: string, hidden = false): ProjectConfig =>
+  ({
+    name,
+    repo: `thonyAGP/${name}`,
+    hasCI: false,
+    stack: 'node',
+    hasQodo: false,
+    hasClaude: false,
+    hasSelfHealing: false,
+    hasHusky: false,
+    hasRenovate: false,
+    hasGitleaks: false,
+    hasLighthouse: false,
+    hasLinkChecker: false,
+    vercel: false,
+    ...(hidden ? { hidden: true } : {}),
+  }) as ProjectConfig;
+
+const projects = [p('Alpha'), p('Beta'), p('Secret', true)];
+
+describe('selectSecretTargets', () => {
+  it('returns all non-hidden repos by default', () => {
+    expect(selectSecretTargets(projects).map((r) => r.name)).toEqual(['Alpha', 'Beta']);
+  });
+
+  it('includes hidden repos when asked', () => {
+    expect(selectSecretTargets(projects, { includeHidden: true }).map((r) => r.name)).toEqual([
+      'Alpha',
+      'Beta',
+      'Secret',
+    ]);
+  });
+
+  it('restricts to --only by short name (case-insensitive)', () => {
+    expect(selectSecretTargets(projects, { only: ['alpha'] }).map((r) => r.name)).toEqual([
+      'Alpha',
+    ]);
+  });
+
+  it('restricts to --only by full owner/name', () => {
+    expect(selectSecretTargets(projects, { only: ['thonyAGP/Beta'] }).map((r) => r.name)).toEqual([
+      'Beta',
+    ]);
+  });
+
+  it('empty --only behaves as no filter', () => {
+    expect(selectSecretTargets(projects, { only: [] }).map((r) => r.name)).toEqual([
+      'Alpha',
+      'Beta',
+    ]);
+  });
+
+  it('--only does not resurrect a hidden repo unless includeHidden', () => {
+    expect(selectSecretTargets(projects, { only: ['Secret'] })).toEqual([]);
+    expect(
+      selectSecretTargets(projects, { only: ['Secret'], includeHidden: true }).map((r) => r.name)
+    ).toEqual(['Secret']);
+  });
+});

--- a/scripts/distribute-remediation-secret.ts
+++ b/scripts/distribute-remediation-secret.ts
@@ -1,0 +1,137 @@
+/**
+ * distribute-remediation-secret.ts
+ *
+ * Pushes the Claude Code OAuth token (subscription auth, no API key) as the
+ * `CLAUDE_CODE_OAUTH_TOKEN` secret onto every managed repo in one pass, so you
+ * don't have to click through 25 repo settings pages. `claude-code-action`
+ * runs *inside* each target repo, so the secret has to live in each repo —
+ * this just automates the tedium.
+ *
+ * The secret sitting in a repo is inert: an agent only runs there when the repo
+ * is BOTH in REMEDIATION_CONFIG.enabledRepos AND has the ai-remediation.yml
+ * workflow deployed. So distributing the secret broadly is safe; remediation
+ * stays gated centrally.
+ *
+ * Security:
+ * - the token is read from the env var CLAUDE_CODE_OAUTH_TOKEN, never an arg
+ * - it is passed to `gh` over stdin (`--body-file -`), never on the command
+ *   line (argv is visible in `ps`) and is never printed
+ *
+ * Usage (run locally, where `gh` is authenticated as the repo owner):
+ *   export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
+ *   pnpm distribute-remediation-secret                 # all managed repos
+ *   pnpm distribute-remediation-secret -- --only zentra,statusline
+ *   pnpm distribute-remediation-secret -- --dry-run    # list targets, set nothing
+ *   pnpm distribute-remediation-secret -- --include-hidden
+ */
+
+import { execFileSync } from 'node:child_process';
+import { KNOWN_PROJECTS, type ProjectConfig } from '../factory.config.js';
+
+const SECRET_NAME = 'CLAUDE_CODE_OAUTH_TOKEN';
+
+export interface SelectOptions {
+  only?: string[]; // repo names or full names to restrict to (case-insensitive)
+  includeHidden?: boolean;
+}
+
+/**
+ * Pure target selection: which repos get the secret. Hidden repos are excluded
+ * unless includeHidden; `only` restricts by short name or `owner/name`.
+ */
+export const selectSecretTargets = (
+  projects: ProjectConfig[],
+  opts: SelectOptions = {}
+): ProjectConfig[] => {
+  const only = opts.only?.map((s) => s.toLowerCase());
+  return projects.filter((p) => {
+    if (!opts.includeHidden && p.hidden) return false;
+    if (!only || only.length === 0) return true;
+    return only.includes(p.name.toLowerCase()) || only.includes(p.repo.toLowerCase());
+  });
+};
+
+const parseArgs = (
+  argv: string[]
+): { only?: string[]; includeHidden: boolean; dryRun: boolean } => {
+  const dryRun = argv.includes('--dry-run');
+  const includeHidden = argv.includes('--include-hidden');
+  const onlyIdx = argv.indexOf('--only');
+  const only =
+    onlyIdx !== -1 && argv[onlyIdx + 1]
+      ? argv[onlyIdx + 1]
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : undefined;
+  return { only, includeHidden, dryRun };
+};
+
+/** Set the secret on one repo via gh, token passed over stdin. Returns true on success. */
+const setSecret = (repo: string, token: string): boolean => {
+  try {
+    execFileSync('gh', ['secret', 'set', SECRET_NAME, '--repo', repo, '--body-file', '-'], {
+      input: token,
+      stdio: ['pipe', 'ignore', 'pipe'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const main = (): void => {
+  const { only, includeHidden, dryRun } = parseArgs(process.argv.slice(2));
+
+  const token = process.env.CLAUDE_CODE_OAUTH_TOKEN?.trim();
+  if (!dryRun) {
+    if (!token) {
+      console.error('✗ CLAUDE_CODE_OAUTH_TOKEN is not set. Export it first:');
+      console.error('    export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...');
+      process.exit(1);
+    }
+    if (!token.startsWith('sk-ant-oat')) {
+      console.error(
+        '✗ CLAUDE_CODE_OAUTH_TOKEN does not look like a subscription OAuth token ' +
+          '(expected prefix sk-ant-oat…). Refusing — did you paste an API key by mistake?'
+      );
+      process.exit(1);
+    }
+  }
+
+  const targets = selectSecretTargets(KNOWN_PROJECTS, { only, includeHidden });
+  if (targets.length === 0) {
+    console.log('No matching repos.');
+    return;
+  }
+
+  console.log(`${dryRun ? '[dry-run] ' : ''}Setting ${SECRET_NAME} on ${targets.length} repo(s):`);
+  let ok = 0;
+  const failed: string[] = [];
+  for (const t of targets) {
+    if (dryRun) {
+      console.log(`  • ${t.repo}`);
+      continue;
+    }
+    if (setSecret(t.repo, token as string)) {
+      ok++;
+      console.log(`  ✓ ${t.repo}`);
+    } else {
+      failed.push(t.repo);
+      console.log(`  ✗ ${t.repo} (gh secret set failed — admin rights? repo exists?)`);
+    }
+  }
+
+  if (!dryRun) {
+    console.log(`\nDone: ${ok}/${targets.length} set.`);
+    if (failed.length) {
+      console.log(`Failed: ${failed.join(', ')}`);
+      process.exit(1);
+    }
+  }
+};
+
+const isDirectRun =
+  !process.env.VITEST &&
+  process.argv[1]?.replace(/\\/g, '/').endsWith('distribute-remediation-secret.ts');
+if (isDirectRun) main();

--- a/scripts/remediation-dispatch.ts
+++ b/scripts/remediation-dispatch.ts
@@ -147,7 +147,9 @@ const main = (): void => {
         t.name
       );
     } else {
-      console.log(`    [WARN] dispatch failed for ${t.repo} (workflow present + API key set?)`);
+      console.log(
+        `    [WARN] dispatch failed for ${t.repo} (ai-remediation.yml present + CLAUDE_CODE_OAUTH_TOKEN set?)`
+      );
     }
   }
 

--- a/templates/ai-remediation.yml
+++ b/templates/ai-remediation.yml
@@ -3,10 +3,15 @@
 # findings and opens a PR — then exits. Dispatched by the Factory's
 # remediation-dispatch for repos graded F in the security registry.
 #
-# Requires (per repo): secret ANTHROPIC_API_KEY. The agent is deliberately
-# constrained: it fixes tractable SAST/dep findings, never touches secrets
-# (rotation is manual), never does large refactors or major bumps, always
-# runs tests, and opens exactly one PR for human review.
+# Requires (per repo):
+#   - secret CLAUDE_CODE_OAUTH_TOKEN (subscription auth, no API billing —
+#     generate with `claude setup-token`, distribute with
+#     `pnpm distribute-remediation-secret`)
+#   - the Claude GitHub App installed on the repo (github.com/apps/claude),
+#     which grants the repo permissions the token uses
+# The agent is deliberately constrained: it fixes tractable SAST/dep findings,
+# never touches secrets (rotation is manual), never does large refactors or
+# major bumps, always runs tests, and opens exactly one PR for human review.
 
 name: AI Remediation
 
@@ -35,7 +40,9 @@ jobs:
       - name: Run remediation agent
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Subscription OAuth token (no API key, no usage-based billing).
+          # See docs/remediation.md and docs/github-app-migration.md.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           direct_prompt: |
             Tu corriges les problèmes de sécurité et de qualité détectés par le
             scan centralisé de DevOps-Factory sur ce repository.


### PR DESCRIPTION
Répond à « ça va me faire chier de poser le token sur 25 repos » : on automatise la partie répétitive et on bascule l'agent sur le token d'abonnement (sans clé API).

## Ce que ça ajoute

- **`scripts/distribute-remediation-secret.ts`** (+ 6 tests) : pousse le secret `CLAUDE_CODE_OAUTH_TOKEN` sur tous les repos gérés **en une passe** (`gh secret set`). Le token est lu depuis l'env et passé à `gh` **par stdin** (jamais en argv — invisible dans `ps` — jamais loggé). Options `--only a,b`, `--dry-run`, `--include-hidden`.
- **`templates/ai-remediation.yml`** : passe de `anthropic_api_key` à **`claude_code_oauth_token`** → auth par abonnement, **aucune facturation à l'usage API**.
- **`docs/remediation.md`** : documente la génération du token (`claude setup-token`), l'install de l'App Claude **en un clic sur *All repositories*** (pas repo par repo), et la distribution en masse du secret.
- Rafraîchit les références périmées à `ANTHROPIC_API_KEY` dans le dispatcher + la config.

## Sûreté préservée

`REMEDIATION_CONFIG` **reste désactivé, allowlist vide** — cette PR ne livre que l'outillage. Un secret posé dans un repo est **inerte** : l'agent n'y tourne que si le repo est **à la fois** dans `enabledRepos` **et** a le workflow déployé. Distribuer le secret largement est donc sans risque ; l'activation reste centralisée.

## Ce qui reste pour activer (une fois un repo choisi)

1. `claude setup-token` (compte perso) → `pnpm distribute-remediation-secret`.
2. Installer l'App Claude sur *All repositories*.
3. Déployer `ai-remediation.yml` (`redeploy-templates`).
4. `REMEDIATION_CONFIG.enabled = true` + `enabledRepos: ['thonyAGP/<un-repo-F>']`.
5. Remediation Dispatch → dry-run puis réel → l'agent ouvre **une PR** que tu relis (pas d'automerge).

908 tests verts, typecheck OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_