### PR TITLE
feat: activer la remédiation supervisée sur lecteur-magic

### DIFF
--- a/factory.config.ts
+++ b/factory.config.ts
@@ -510,8 +510,10 @@ export interface RemediationConfig {
  * each target repo. Guardrails: allowlist, grade gate, daily quota.
  */
 export const REMEDIATION_CONFIG: RemediationConfig = {
-  enabled: false,
-  enabledRepos: [],
+  enabled: true,
+  // Supervised rollout: one repo first. The agent opens a PR for human review
+  // (no automerge). Widen this list only once the loop is trusted.
+  enabledRepos: ['thonyAGP/lecteur-magic'],
   minGrade: 'F',
   maxPerDay: 2,
   workflowFile: 'ai-remediation.yml',


### PR DESCRIPTION
Active la boucle de remédiation autonome sur **un seul repo** (`thonyAGP/lecteur-magic`, un des pires F) pour la valider de bout en bout.

`REMEDIATION_CONFIG` : `enabled: true` + `enabledRepos: ['thonyAGP/lecteur-magic']`.

Tout le reste des garde-fous reste en place :
- gate de note **F**, quota **2/jour**
- **dispatch manuel uniquement** (aucun cron)
- l'agent ouvre **une PR** relue par un humain — **pas d'automerge**

Élargir l'allowlist plus tard = une ligne, une fois la boucle éprouvée.

## Prérequis restants (côté toi, une fois)
- Secret `CLAUDE_CODE_OAUTH_TOKEN` sur les repos ✅ (fait — script de distribution)
- Installer l'**App Claude** sur *All repositories* (github.com/apps/claude)
- Déployer `ai-remediation.yml` dans `lecteur-magic`

Puis : Actions → **Remediation Dispatch** → dry-run (voir la cible), puis réel → l'agent ouvre sa PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_