### PR TITLE
feat: politique minutes — les repos privés ne brûlent plus le quota Actions

### DIFF
--- a/.github/workflows/retire-private-workflows.yml
+++ b/.github/workflows/retire-private-workflows.yml
@@ -1,0 +1,73 @@
+# DevOps-Factory: Retire Private Workflows (minutes policy)
+# Private repos share one 2000 free-min/month Actions pool; the Factory
+# (public) is the fleet's only intended consumer. This opens one cleanup PR
+# per private repo removing factory-deployed workflows that are covered
+# centrally. Manual dispatch only, dry-run by default.
+
+name: Retire Private Workflows
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List deletions without opening PRs'
+        required: false
+        default: true
+        type: boolean
+      only:
+        description: 'Comma-separated repo names to restrict to (empty = all)'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: retire-private-workflows
+  cancel-in-progress: false
+
+jobs:
+  retire:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # GitHub App token (short-lived, 1h) — sole auth since the PAT was
+      # retired. See docs/github-app-migration.md.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.FACTORY_APP_ID }}
+          private-key: ${{ secrets.FACTORY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Retire private workflows
+        run: |
+          ARGS=""
+          if [ "$DRY_RUN" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          if [ -n "$ONLY" ]; then
+            ARGS="$ARGS --only $ONLY"
+          fi
+          pnpm retire-private-workflows -- $ARGS
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          ONLY: ${{ inputs.only }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/factory.config.ts
+++ b/factory.config.ts
@@ -519,6 +519,22 @@ export const REMEDIATION_CONFIG: RemediationConfig = {
   workflowFile: 'ai-remediation.yml',
 };
 
+/**
+ * Minutes policy: private repos share one 2000 free-min/month Actions pool,
+ * while DevOps-Factory (public) has unlimited free minutes — so the Factory
+ * must be the fleet's only real consumer. Only these workflow files may live
+ * in a PRIVATE repo; everything else runs centrally (central-scan,
+ * central-coverage, central renovate, self-heal, claude-review) or not at
+ * all. scan-and-configure enforces this at deploy time;
+ * retire-private-workflows purges already-deployed offenders via PRs.
+ */
+export const PRIVATE_WORKFLOW_ALLOWLIST: readonly string[] = [
+  '.github/workflows/ci.yml', // the PR/push test gate (also gates renovate automerge)
+  '.github/workflows/auto-merge-deps.yml', // seconds-long; lets central Renovate automerge
+  '.github/workflows/ai-remediation.yml', // workflow_dispatch only — inert until dispatched
+  '.github/workflows/prisma-migration-check.yml', // path-filtered, rare, real safety net
+];
+
 export const GITHUB_OWNER = 'thonyAGP';
 
 export const DASHBOARD_URL = 'https://thonyagp.github.io/DevOps-Factory/';

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "security-registry": "tsx scripts/security-registry.ts",
     "remediation-dispatch": "tsx scripts/remediation-dispatch.ts",
     "distribute-remediation-secret": "tsx scripts/distribute-remediation-secret.ts",
+    "retire-private-workflows": "tsx scripts/retire-private-workflows.ts",
     "template-drift": "tsx scripts/template-drift.ts",
     "dora": "tsx scripts/dora-metrics.ts",
     "cost-monitor": "tsx scripts/cost-monitor.ts",

--- a/scripts/retire-private-workflows.test.ts
+++ b/scripts/retire-private-workflows.test.ts
@@ -1,0 +1,61 @@
+/**
+ * retire-private-workflows.test.ts
+ *
+ * The selection drives file DELETIONS in managed repos, so the invariants are
+ * tested explicitly: only known factory files, never the allowlist, never a
+ * repo's own workflows.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  selectRetireTargets,
+  FACTORY_RETIRED_WORKFLOWS,
+  type RemoteWorkflowFile,
+} from './retire-private-workflows.js';
+import { PRIVATE_WORKFLOW_ALLOWLIST } from '../factory.config.js';
+
+const f = (name: string): RemoteWorkflowFile => ({ name, sha: `sha-${name}` });
+
+describe('selectRetireTargets', () => {
+  it('retires factory-deployed workflows', () => {
+    const got = selectRetireTargets([f('semgrep.yml'), f('gitleaks.yml'), f('self-healing.yml')]);
+    expect(got.map((x) => x.name)).toEqual(['semgrep.yml', 'gitleaks.yml', 'self-healing.yml']);
+  });
+
+  it('never touches a repo own custom workflows', () => {
+    const got = selectRetireTargets([f('deploy-prod.yml'), f('my-custom-thing.yml')]);
+    expect(got).toEqual([]);
+  });
+
+  it('never touches allowlisted workflows', () => {
+    const got = selectRetireTargets([
+      f('ci.yml'),
+      f('auto-merge-deps.yml'),
+      f('ai-remediation.yml'),
+      f('prisma-migration-check.yml'),
+    ]);
+    expect(got).toEqual([]);
+  });
+
+  it('allowlist wins even if a name lands on both lists', () => {
+    const got = selectRetireTargets([f('ci.yml')], ['ci.yml'], ['.github/workflows/ci.yml']);
+    expect(got).toEqual([]);
+  });
+
+  it('mixes correctly: retire the covered ones, keep custom + allowlisted', () => {
+    const got = selectRetireTargets([
+      f('ci.yml'),
+      f('coverage-gate.yml'),
+      f('deploy-prod.yml'),
+      f('claude-review.yml'),
+    ]);
+    expect(got.map((x) => x.name)).toEqual(['coverage-gate.yml', 'claude-review.yml']);
+  });
+
+  it('the retired list and the allowlist are disjoint (config invariant)', () => {
+    const allowNames = new Set(PRIVATE_WORKFLOW_ALLOWLIST.map((p) => p.split('/').pop()));
+    for (const name of FACTORY_RETIRED_WORKFLOWS) {
+      expect(allowNames.has(name), `${name} is in both lists`).toBe(false);
+    }
+  });
+});

--- a/scripts/retire-private-workflows.ts
+++ b/scripts/retire-private-workflows.ts
@@ -1,0 +1,219 @@
+/**
+ * retire-private-workflows.ts
+ *
+ * Minutes-policy enforcement (the "Factory is the fleet's only Actions
+ * consumer" doctrine): private repos share one 2000 free-min/month pool, and
+ * the ~30 per-repo workflows historically deployed by scan-and-configure fire
+ * on every push/PR — central Renovate's daily PRs alone can burn the whole
+ * pool. This script removes those workflows from PRIVATE repos via one
+ * cleanup PR per repo; their jobs are covered centrally (central-scan,
+ * central-coverage, central renovate, self-heal, claude-review) or dropped.
+ *
+ * Safety:
+ * - only files in FACTORY_RETIRED_WORKFLOWS are ever touched — a repo's own
+ *   hand-written workflows are invisible to this script
+ * - PRIVATE repos only (public repos have unlimited free minutes)
+ * - one PR per repo, for human review — nothing is pushed to default branches
+ * - --dry-run (default in CI) lists deletions without acting
+ *
+ * Usage: pnpm retire-private-workflows [-- --dry-run] [-- --only casasync]
+ */
+
+import { KNOWN_PROJECTS, PRIVATE_WORKFLOW_ALLOWLIST } from '../factory.config.js';
+import { logActivity } from './activity-logger.js';
+import { sh } from './shell-utils.js';
+
+/**
+ * Every workflow file the Factory has ever deployed to managed repos and that
+ * must NOT live in a private repo. Kept explicit (not derived) because this
+ * drives deletions: anything absent from this list is never touched.
+ */
+export const FACTORY_RETIRED_WORKFLOWS: readonly string[] = [
+  'accessibility-check.yml',
+  'auto-codeowners.yml',
+  'auto-label.yml',
+  'auto-test-gen.yml',
+  'branch-cleanup.yml',
+  'business-metrics.yml',
+  'claude-review.yml',
+  'claude-usage-roi.yml',
+  'competitive-analysis.yml',
+  'config-drift.yml',
+  'container-scan.yml',
+  'coverage-gate.yml',
+  'cron-monitor.yml',
+  'dead-code-detection.yml',
+  'dependency-size-check.yml',
+  'env-sync-check.yml',
+  'gitleaks.yml',
+  'license-check.yml',
+  'lighthouse.yml',
+  'link-checker.yml',
+  'mutation-testing.yml',
+  'node-version-sync.yml',
+  'openspec-drift.yml',
+  'performance-budget.yml',
+  'pr-description-ai.yml',
+  'pr-risk-assessment.yml',
+  'pr-size-limiter.yml',
+  'qodo-merge.yml',
+  'readme-freshness.yml',
+  'sbom-generation.yml',
+  'security-headers.yml',
+  'self-healing.yml',
+  'semgrep.yml',
+  'seo-check.yml',
+  'ssl-check.yml',
+  'supply-chain-security.yml',
+  'test-impact-analysis.yml',
+  'type-coverage.yml',
+  'typedoc-gen.yml',
+  'uptime-monitor.yml',
+  'weekly-digest.yml',
+];
+
+export interface RemoteWorkflowFile {
+  name: string;
+  sha: string;
+}
+
+/**
+ * Pure selection: which of a repo's workflow files must be retired.
+ * Intersection with the explicit retired list, minus the allowlist (defense
+ * in depth — a file can never be both, but the invariant is cheap to hold).
+ */
+export const selectRetireTargets = (
+  files: RemoteWorkflowFile[],
+  retired: readonly string[] = FACTORY_RETIRED_WORKFLOWS,
+  allowlist: readonly string[] = PRIVATE_WORKFLOW_ALLOWLIST
+): RemoteWorkflowFile[] => {
+  const allowNames = new Set(allowlist.map((p) => p.split('/').pop() as string));
+  const retiredSet = new Set(retired);
+  return files.filter((f) => retiredSet.has(f.name) && !allowNames.has(f.name));
+};
+
+const ghJson = <T>(cmd: string): T | null => {
+  const out = sh(`gh ${cmd}`, { maxBuffer: 10 * 1024 * 1024 });
+  if (!out) return null;
+  try {
+    return JSON.parse(out) as T;
+  } catch {
+    return null;
+  }
+};
+
+const listWorkflowFiles = (repo: string): RemoteWorkflowFile[] => {
+  const files = ghJson<{ name: string; sha: string; type: string }[]>(
+    `api "repos/${repo}/contents/.github/workflows" 2>/dev/null`
+  );
+  if (!Array.isArray(files)) return [];
+  return files.filter((f) => f.type === 'file').map((f) => ({ name: f.name, sha: f.sha }));
+};
+
+const isPrivateRepo = (repo: string): boolean =>
+  sh(`gh api "repos/${repo}" --jq .private`) === 'true';
+
+const BRANCH = 'devops-factory/retire-private-workflows';
+
+const createRetirePR = (repo: string, targets: RemoteWorkflowFile[]): string | null => {
+  const defaultBranch = sh(`gh api "repos/${repo}" --jq .default_branch`) || 'main';
+  const baseSha = sh(`gh api "repos/${repo}/git/ref/heads/${defaultBranch}" --jq .object.sha`);
+  if (!baseSha) return null;
+
+  const branchRef = sh(
+    `gh api "repos/${repo}/git/refs" -f ref="refs/heads/${BRANCH}" -f sha="${baseSha}" 2>&1`
+  );
+  if (!branchRef.includes(BRANCH)) return null;
+
+  let deleted = 0;
+  for (const t of targets) {
+    const res = sh(
+      `gh api -X DELETE "repos/${repo}/contents/.github/workflows/${t.name}" ` +
+        `-f message="chore: retire ${t.name} (covered by the central factory)" ` +
+        `-f sha="${t.sha}" -f branch="${BRANCH}"`
+    );
+    if (res.includes('commit')) deleted++;
+  }
+  if (deleted === 0) return null;
+
+  const names = targets.map((t) => `- \`${t.name}\``).join('\n');
+  const body =
+    `Retire les workflows par-repo couverts par l'usine centrale (repo public → minutes illimitées), ` +
+    `pour que ce repo privé ne consomme plus le pool 2000 min/mois :\n\n${names}\n\n` +
+    `Couverture centrale : sécurité/duplication → Central Security Scan (hebdo), ` +
+    `couverture → Central Coverage (hebdo), dépendances → Central Renovate (quotidien), ` +
+    `self-heal & review → workflows Factory. Restent ici : la CI, auto-merge-deps et ` +
+    `l'agent de remédiation (dispatch uniquement).\n\n*Généré par DevOps-Factory (minutes policy)*`;
+  const pr = sh(
+    `gh pr create --repo ${repo} --head ${BRANCH} --base ${defaultBranch} ` +
+      `--title "chore: retirer les workflows couverts par l'usine centrale (économie de minutes)" ` +
+      `--body "${body.replace(/"/g, '\\"')}"`
+  );
+  return pr.match(/(https:\/\/[^\s]+)/)?.[1] || null;
+};
+
+const main = (): void => {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const onlyIdx = args.indexOf('--only');
+  const only =
+    onlyIdx !== -1 && args[onlyIdx + 1]
+      ? args[onlyIdx + 1].split(',').map((s) => s.trim().toLowerCase())
+      : null;
+
+  const projects = KNOWN_PROJECTS.filter((p) => !p.hidden).filter(
+    (p) =>
+      !only ||
+      only.includes(p.name.toLowerCase()) ||
+      only.includes(p.repo.toLowerCase()) ||
+      only.includes(p.repo.split('/')[1].toLowerCase())
+  );
+
+  let totalFiles = 0;
+  let prs = 0;
+  for (const project of projects) {
+    if (!isPrivateRepo(project.repo)) {
+      console.log(`  [SKIP] ${project.name}: public (free minutes)`);
+      continue;
+    }
+    const files = listWorkflowFiles(project.repo);
+    const targets = selectRetireTargets(files);
+    if (targets.length === 0) {
+      console.log(`  [OK]   ${project.name}: nothing to retire`);
+      continue;
+    }
+    totalFiles += targets.length;
+    console.log(
+      `  [${dryRun ? 'DRY' : 'PR '}]  ${project.name}: ${targets.length} workflow(s) → ${targets
+        .map((t) => t.name)
+        .join(', ')}`
+    );
+    if (dryRun) continue;
+
+    const url = createRetirePR(project.repo, targets);
+    if (url) {
+      prs++;
+      console.log(`         PR: ${url}`);
+      logActivity(
+        'redeploy-templates',
+        'retire-workflows',
+        `${targets.length} workflow(s) retired`,
+        'warning',
+        project.name
+      );
+    } else {
+      console.log(`         [WARN] PR creation failed (branch already exists?)`);
+    }
+  }
+
+  console.log(
+    `\n${dryRun ? '[dry-run] ' : ''}${totalFiles} workflow file(s) across fleet${
+      dryRun ? ' would be retired' : `, ${prs} PR(s) opened`
+    }.`
+  );
+};
+
+const isDirectRun =
+  !process.env.VITEST &&
+  process.argv[1]?.replace(/\\/g, '/').endsWith('retire-private-workflows.ts');
+if (isDirectRun) main();

--- a/scripts/scan-and-configure.ts
+++ b/scripts/scan-and-configure.ts
@@ -16,6 +16,7 @@ import { jq, devNull } from './shell-utils.js';
 import { getCached, setCache } from './cache-manager.js';
 import { batchFileExists, fileExistsInRepo } from './github-file-checker.js';
 import { loadRepoConfig, renderTemplate } from './template-config.js';
+import { PRIVATE_WORKFLOW_ALLOWLIST } from '../factory.config.js';
 
 interface Repo {
   name: string;
@@ -623,6 +624,24 @@ const createConfigPR = (analysis: RepoAnalysis): void => {
       path: '.github/workflows/typedoc-gen.yml',
       template: `${TEMPLATES_DIR}/typedoc-gen.yml`,
     });
+  }
+
+  // Minutes policy: private repos share the 2000 free-min/month pool, so only
+  // allowlisted workflows may be deployed there — everything else runs
+  // centrally from the (public, free) Factory. See PRIVATE_WORKFLOW_ALLOWLIST.
+  if (repo.private) {
+    const before = filesToAdd.length;
+    const kept = filesToAdd.filter(
+      (f) => !f.path.startsWith('.github/workflows/') || PRIVATE_WORKFLOW_ALLOWLIST.includes(f.path)
+    );
+    const suppressed = before - kept.length;
+    if (suppressed > 0) {
+      console.log(
+        `  [POLICY] ${repo.name}: ${suppressed} workflow(s) withheld (private repo — covered centrally)`
+      );
+    }
+    filesToAdd.length = 0;
+    filesToAdd.push(...kept);
   }
 
   if (filesToAdd.length === 0) {


### PR DESCRIPTION
Réponse au diagnostic « 2000 min consommées en 7 jours » : `scan-and-configure` déployait **~30 workflows par repo privé**, la plupart déclenchés à chaque push/PR — multipliés par les PRs quotidiennes du Renovate central. CasaSync seul ≈ 1250 min. Doctrine actée : **DevOps-Factory (public, minutes illimitées) est l'unique consommateur** ; les repos privés tendent vers 0 minute.

## Les trois pièces

**1. La politique — `PRIVATE_WORKFLOW_ALLOWLIST`** (`factory.config.ts`)
Seuls 4 workflows ont le droit de vivre dans un repo privé :
- `ci.yml` — le gate de tests PR/push (nécessaire aussi à l'automerge Renovate)
- `auto-merge-deps.yml` — quelques secondes par PR Renovate
- `ai-remediation.yml` — `workflow_dispatch` uniquement, inerte sans dispatch
- `prisma-migration-check.yml` — path-filtered, rare, vrai filet de sécurité

**2. Le verrou — `scan-and-configure`**
Retient désormais tout workflow non-allowlisté pour les repos privés (`[POLICY] N workflow(s) withheld`). Sans ça, la purge serait annulée au scan suivant. (`redeploy-templates` ne ré-ajoute jamais un fichier absent — vérifié.)

**3. La purge — `retire-private-workflows`** (script + workflow, dry-run par défaut)
Ouvre **une PR de nettoyage par repo privé** supprimant les workflows Factory couverts centralement (~40 noms **explicitement listés** — un workflow custom écrit par toi n'est jamais touché). Couverture : sécurité/duplication → Central Scan, couverture → Central Coverage, deps → Central Renovate, self-heal & review → Factory.

## Invariants testés
6 nouveaux tests, dont : jamais un workflow custom, jamais l'allowlist, et **disjonction allowlist/liste-retirée** vérifiée en test. 914 tests verts, typecheck OK.

## Après merge
1. Actions → **Retire Private Workflows** → Run (dry-run) → liste ce qui serait supprimé par repo.
2. Re-run `dry_run: false` → une PR de nettoyage par repo, à merger.
3. La consommation privée retombe à : CI sur vraies PRs + quelques secondes d'auto-merge — de ~285 min/jour à quelques min/jour.

Trade-offs assumés (documentés) : perte du ratchet coverage-gate par PR (mesure hebdo centrale conservée) et des checks per-PR semgrep (scan central hebdo conservé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_