### PR TITLE
fix: quota journalier persistant + corps de PR sûrs (durcissement avant minutes payantes)

### DIFF
--- a/.github/workflows/remediation-dispatch.yml
+++ b/.github/workflows/remediation-dispatch.yml
@@ -62,3 +62,20 @@ jobs:
         env:
           DRY_RUN: ${{ inputs.dry_run }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # Persist the daily quota so maxPerDay actually holds across runs —
+      # without this the counter dies with the runner and the cap is a no-op.
+      - name: Commit quota state
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          git config user.name "DevOps Factory Bot"
+          git config user.email "devops-factory[bot]@users.noreply.github.com"
+          if [ -f data/remediation-quota.json ]; then
+            cp data/remediation-quota.json /tmp/remediation-quota.json
+            git fetch origin master
+            git reset --hard origin/master
+            cp /tmp/remediation-quota.json data/remediation-quota.json
+            git add data/remediation-quota.json
+            git diff --cached --quiet || git commit -m "chore: update remediation quota" --no-verify
+            git push origin master
+          fi

--- a/scripts/retire-private-workflows.ts
+++ b/scripts/retire-private-workflows.ts
@@ -19,9 +19,10 @@
  * Usage: pnpm retire-private-workflows [-- --dry-run] [-- --only casasync]
  */
 
+import { writeFileSync, unlinkSync } from 'node:fs';
 import { KNOWN_PROJECTS, PRIVATE_WORKFLOW_ALLOWLIST } from '../factory.config.js';
 import { logActivity } from './activity-logger.js';
-import { sh } from './shell-utils.js';
+import { sh, tmpDir } from './shell-utils.js';
 
 /**
  * Every workflow file the Factory has ever deployed to managed repos and that
@@ -144,11 +145,20 @@ const createRetirePR = (repo: string, targets: RemoteWorkflowFile[]): string | n
     `couverture → Central Coverage (hebdo), dépendances → Central Renovate (quotidien), ` +
     `self-heal & review → workflows Factory. Restent ici : la CI, auto-merge-deps et ` +
     `l'agent de remédiation (dispatch uniquement).\n\n*Généré par DevOps-Factory (minutes policy)*`;
+  // Body goes through a file: inline shell strings would let the markdown
+  // backticks be executed as command substitutions.
+  const bodyFile = `${tmpDir}/retire-body-${targets[0].sha.slice(0, 8)}.md`;
+  writeFileSync(bodyFile, body);
   const pr = sh(
     `gh pr create --repo ${repo} --head ${BRANCH} --base ${defaultBranch} ` +
       `--title "chore: retirer les workflows couverts par l'usine centrale (économie de minutes)" ` +
-      `--body "${body.replace(/"/g, '\\"')}"`
+      `--body-file "${bodyFile}"`
   );
+  try {
+    unlinkSync(bodyFile);
+  } catch {
+    /* best effort */
+  }
   return pr.match(/(https:\/\/[^\s]+)/)?.[1] || null;
 };
 


### PR DESCRIPTION
Deux durcissements avant de dépenser des minutes payantes :

- **`remediation-dispatch.yml`** commite désormais `data/remediation-quota.json` sur master après un dispatch réel. Sans ça, le compteur mourait avec le runner et le plafond `maxPerDay: 2` était **inopérant d'un run à l'autre** — un trou réel maintenant que chaque agent coûte des minutes facturées.
- **`retire-private-workflows`** passe les corps de PR par un fichier (`--body-file`) : les backticks markdown dans une chaîne shell double-quotée étaient exécutés comme substitutions de commande — d'où les listes à puces vides dans les 20 PRs de nettoyage et le bruit `not found` dans les logs.

Typecheck OK, tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_