### PR TITLE
fix: id-token write dans le template de l'agent de remédiation

### DIFF
--- a/templates/ai-remediation.yml
+++ b/templates/ai-remediation.yml
@@ -23,6 +23,9 @@ permissions:
   contents: write
   pull-requests: write
   issues: read
+  # claude-code-action exchanges an OIDC token with the Claude GitHub App
+  # to mint its GitHub access — without this the action dies at startup.
+  id-token: write
 
 concurrency:
   group: ai-remediation


### PR DESCRIPTION
Premier run financé de l'agent (LecteurMagic run #2) : `claude-code-action` meurt au démarrage avec `Could not fetch an OIDC token` — l'action s'authentifie en échangeant un token OIDC avec l'App Claude, ce qui exige **`id-token: write`** dans les permissions du workflow. Ajouté au template `ai-remediation.yml` (déjà corrigé à la main dans LecteurMagic via LecteurMagic#42).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_