### PR TITLE
fix: mode agent dans le template de remédiation

### DIFF
--- a/templates/ai-remediation.yml
+++ b/templates/ai-remediation.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Run remediation agent
         uses: anthropics/claude-code-action@beta
         with:
+          # workflow_dispatch is an automation event — the default 'tag' mode
+          # only handles @claude mentions and refuses it.
+          mode: agent
           # Subscription OAuth token (no API key, no usage-based billing).
           # See docs/remediation.md and docs/github-app-migration.md.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Run #3 sur LecteurMagic : `Tag mode cannot handle workflow_dispatch events. Use 'agent' mode for automation events.` Le mode par défaut de `claude-code-action@beta` ne gère que les mentions `@claude` ; nos déclenchements sont des `workflow_dispatch` → `mode: agent` ajouté au template (déjà appliqué à LecteurMagic via LecteurMagic#43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_