### PR TITLE
fix: épingler le modèle de l'agent de remédiation (défaut retiré)

### DIFF
--- a/templates/ai-remediation.yml
+++ b/templates/ai-remediation.yml
@@ -46,6 +46,8 @@ jobs:
           # workflow_dispatch is an automation event — the default 'tag' mode
           # only handles @claude mentions and refuses it.
           mode: agent
+          # The action's default model (sonnet-4) is retired and 404s.
+          model: claude-sonnet-5
           # Subscription OAuth token (no API key, no usage-based billing).
           # See docs/remediation.md and docs/github-app-migration.md.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Run #4 sur LecteurMagic : l'agent démarre enfin sur le token d'abonnement (**`apiKeySource: none`, coût API 0 $** — la voie « sans clé API » est confirmée en réel) mais meurt sur `404 model: claude-sonnet-4-20250514` — le modèle par défaut de `claude-code-action@beta` est retiré. On épingle **`claude-sonnet-5`** dans le template (déjà appliqué à LecteurMagic via LecteurMagic#44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_