### PR TITLE
fix: budget de tours de l'agent + PR ouverte tôt (template)

### DIFF
--- a/templates/ai-remediation.yml
+++ b/templates/ai-remediation.yml
@@ -80,7 +80,15 @@ jobs:
               requise (secrets, majeures).
             - Commits conventionnels et atomiques.
 
-            Commence par l'issue `central-scan`, établis un plan priorisé, puis
-            exécute et ouvre la PR.
+            MÉTHODE (budget de tours limité)
+            - N'explore pas le repo en profondeur : l'issue `central-scan` te
+              donne fichier:ligne — va directement aux fichiers cités.
+            - Priorise 2-3 corrections sûres plutôt que l'exhaustivité.
+            - Dès la première correction faite : crée la branche, commit, push,
+              OUVRE LA PR (`gh pr create`). Ajoute les corrections suivantes en
+              commits sur la même branche. Mieux vaut une PR partielle avec les
+              reports documentés qu'aucune PR.
+
+            Commence par l'issue `central-scan`, puis exécute.
           allowed_tools: 'Bash,Edit,Write,Read,Grep,Glob'
-          max_turns: '30'
+          max_turns: '80'


### PR DESCRIPTION
Run #5 sur LecteurMagic : l'agent a tourné de bout en bout (démarrage 100 % OK, ~0,57 $ équivalent pris sur l'abonnement, 0 $ facturé) mais est mort à `error_max_turns` (30 tours) **sans ouvrir sa PR** — budget épuisé en exploration d'un gros repo.

Deux ajustements dans le template :
- `max_turns: 30 → 80` — le `timeout-minutes: 30` reste le plafond dur côté minutes.
- Section **MÉTHODE** dans le prompt : aller droit aux fichiers cités par l'issue (pas d'exploration), prioriser 2-3 corrections sûres, et **ouvrir la PR dès la première correction** puis empiler les commits — une coupure de budget ne peut plus laisser zéro livrable.

Déjà appliqué à LecteurMagic (LecteurMagic#45).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_