### PR TITLE
feat: remédiation vague 2 — 3 repos F de plus, workflow auto-déployé

### DIFF
--- a/factory.config.ts
+++ b/factory.config.ts
@@ -511,11 +511,17 @@ export interface RemediationConfig {
  */
 export const REMEDIATION_CONFIG: RemediationConfig = {
   enabled: true,
-  // Supervised rollout: one repo first. The agent opens a PR for human review
-  // (no automerge). Widen this list only once the loop is trusted.
-  enabledRepos: ['thonyAGP/lecteur-magic'],
+  // Supervised rollout, wave 2: the LecteurMagic pilot delivered a clean PR
+  // (LecteurMagic#46), so the next worst-graded F repos join. LecteurMagic is
+  // out until its PR is merged — keeping it listed would dispatch a duplicate
+  // agent onto work that is already awaiting review.
+  enabledRepos: [
+    'thonyAGP/magic-migration',
+    'thonyAGP/ClubMedRoomAssignment',
+    'thonyAGP/Email_Assistant',
+  ],
   minGrade: 'F',
-  maxPerDay: 2,
+  maxPerDay: 4,
   workflowFile: 'ai-remediation.yml',
 };
 

--- a/scripts/remediation-dispatch.ts
+++ b/scripts/remediation-dispatch.ts
@@ -88,7 +88,9 @@ const loadQuota = (): Quota => {
   try {
     const q = JSON.parse(readFileSync(QUOTA_PATH, 'utf-8')) as Quota;
     if (q.date !== today) return { date: today, count: 0, maxPerDay: REMEDIATION_CONFIG.maxPerDay };
-    return q;
+    // The file only tracks today's count — maxPerDay always comes from config,
+    // otherwise a config bump would be ignored until the next day.
+    return { ...q, maxPerDay: REMEDIATION_CONFIG.maxPerDay };
   } catch {
     return { date: today, count: 0, maxPerDay: REMEDIATION_CONFIG.maxPerDay };
   }
@@ -102,6 +104,37 @@ const dispatchAgent = (repo: string): boolean => {
     `gh workflow run ${REMEDIATION_CONFIG.workflowFile} --repo ${repo} 2>&1 && echo DISPATCHED`
   );
   return out.includes('DISPATCHED');
+};
+
+const WORKFLOW_PATH = `.github/workflows/ai-remediation.yml`;
+const TEMPLATE_PATH = 'templates/ai-remediation.yml';
+
+/**
+ * Onboarding: an allowlisted repo without the agent workflow gets it deployed
+ * directly (the Factory App has workflows write). Returns true when the
+ * workflow exists (already there or just created) and dispatch can proceed —
+ * newly created workflows are immediately dispatchable on the default branch.
+ */
+const ensureWorkflowDeployed = (repo: string): boolean => {
+  const exists = sh(`gh api "repos/${repo}/contents/${WORKFLOW_PATH}" --jq .sha 2>/dev/null`);
+  if (exists) return true;
+  if (!existsSync(TEMPLATE_PATH)) {
+    console.log(`    [WARN] ${TEMPLATE_PATH} missing locally — cannot deploy to ${repo}`);
+    return false;
+  }
+  const content = Buffer.from(readFileSync(TEMPLATE_PATH, 'utf-8')).toString('base64');
+  const res = sh(
+    `gh api -X PUT "repos/${repo}/contents/${WORKFLOW_PATH}" ` +
+      `-f message="ci: deploy ai remediation agent workflow (devops-factory)" ` +
+      `-f content="${content}"`
+  );
+  if (res.includes('commit')) {
+    console.log(`    [DEPLOY] ${WORKFLOW_PATH} created in ${repo}`);
+    logActivity('remediation-dispatch', 'workflow-deployed', WORKFLOW_PATH, 'info', repo);
+    return true;
+  }
+  console.log(`    [WARN] failed to deploy ${WORKFLOW_PATH} to ${repo}`);
+  return false;
 };
 
 const main = (): void => {
@@ -135,6 +168,7 @@ const main = (): void => {
   for (const t of targets) {
     console.log(`  ${t.grade} ${t.name} (risk ${t.risk}) — ${t.reasons.join(', ')}`);
     if (dryRun) continue;
+    if (!ensureWorkflowDeployed(t.repo)) continue;
     if (dispatchAgent(t.repo)) {
       dispatched++;
       quota.count++;


### PR DESCRIPTION
Le pilote LecteurMagic a livré une PR supervisée propre (LecteurMagic#46 : vraie faille CORS corrigée, faux positif justifié, axios bump + CVE, secrets analysés) → la boucle s'élargit.

## Changements

- **Allowlist vague 2** : `magic-migration` (risk 325), `ClubMedRoomAssignment` (315), `Email_Assistant` (300). **LecteurMagic sort de la liste** tant que sa PR n'est pas mergée — le garder redéclencherait un agent en doublon sur du travail déjà en review.
- **`maxPerDay: 2 → 4`** + fix : `loadQuota` prend désormais toujours `maxPerDay` depuis la config (le fichier persisté ne fait foi que pour le compteur du jour) — sinon un bump de config était ignoré jusqu'au lendemain.
- **Workflow auto-déployé** : le dispatcher crée `.github/workflows/ai-remediation.yml` dans un repo allowlisté qui ne l'a pas (l'App Factory a `workflows: write`). Onboarder une vague = une ligne d'allowlist, plus de copie manuelle par repo.

914 tests verts, typecheck OK.

## Après merge
Actions → **Remediation Dispatch** → dry-run décoché. Quota du jour : 2/4 déjà consommés → **2 agents partiront aujourd'hui** (magic-migration + ClubMedRoomAssignment, les 2 pires risques), Email_Assistant suivra demain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCkcY6h8cjMap9JNXeFVj)_