### PR TITLE
fix(test-scaffold): generation idempotente et squelettes qui passent le lint

### DIFF
--- a/scripts/test-scaffold.test.ts
+++ b/scripts/test-scaffold.test.ts
@@ -1,0 +1,125 @@
+/**
+ * test-scaffold.test.ts
+ *
+ * Tests du generateur de squelettes de tests.
+ *
+ * Contrairement aux autres tests de ce depot, celui-ci importe les VRAIES
+ * fonctions au lieu de redeclarer leurs constantes : un test qui verifie sa
+ * propre copie ne protege de rien.
+ *
+ * Regression couverte : le generateur produisait `foo.test.test.ts` puis
+ * `foo.test.test.test.ts`, et des squelettes qui cassaient le lint du depot
+ * cible (PR CasaSync #287 et #295, fermees).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isSkippedFile,
+  findSourceFiles,
+  findUncoveredFiles,
+  generateTestSkeleton,
+} from './test-scaffold.js';
+import type { TreeNode } from './types.js';
+
+const blob = (path: string): TreeNode => ({ path, type: 'blob' }) as TreeNode;
+
+describe('isSkippedFile', () => {
+  it('ignore les fichiers de test — sans quoi ils deviennent des candidats', () => {
+    expect(isSkippedFile('src/lib/foo.test.ts')).toBe(true);
+    expect(isSkippedFile('src/lib/foo.test.tsx')).toBe(true);
+    expect(isSkippedFile('src/lib/foo.spec.ts')).toBe(true);
+    expect(isSkippedFile('src/lib/foo.spec.tsx')).toBe(true);
+  });
+
+  it('ignore aussi les suffixes deja empiles par les anciens passages', () => {
+    expect(isSkippedFile('src/lib/foo.test.test.ts')).toBe(true);
+    expect(isSkippedFile('src/lib/foo.test.test.test.ts')).toBe(true);
+  });
+
+  it('laisse passer une vraie source', () => {
+    expect(isSkippedFile('src/lib/foo.ts')).toBe(false);
+    expect(isSkippedFile('src/components/Bar.tsx')).toBe(false);
+  });
+
+  it('conserve les exclusions historiques', () => {
+    expect(isSkippedFile('src/types/global.d.ts')).toBe(true);
+    expect(isSkippedFile('src/lib/vitest.config.ts')).toBe(true);
+    expect(isSkippedFile('src/lib/index.ts')).toBe(true);
+  });
+});
+
+describe('findSourceFiles', () => {
+  it('exclut les fichiers de test de l arbre', () => {
+    const tree = [
+      blob('src/lib/foo.ts'),
+      blob('src/lib/foo.test.ts'),
+      blob('src/lib/bar.tsx'),
+      blob('src/lib/bar.spec.tsx'),
+    ];
+    expect(findSourceFiles(tree)).toEqual(['src/lib/foo.ts', 'src/lib/bar.tsx']);
+  });
+});
+
+describe('idempotence — la regression des suffixes empiles', () => {
+  it('un second passage ne genere plus rien quand tout est couvert', () => {
+    const tree = [blob('src/lib/foo.ts'), blob('src/lib/foo.test.ts')];
+    const all = tree.map((n) => n.path);
+
+    const premierPassage = findUncoveredFiles(findSourceFiles(tree), all);
+    expect(premierPassage).toEqual([]);
+  });
+
+  it('ne propose JAMAIS foo.test.test.ts', () => {
+    // Avant le correctif : `foo.test.ts` etait vu comme une source, on
+    // cherchait `foo.test.test.ts`, absent, donc on le generait.
+    const tree = [blob('src/lib/foo.ts'), blob('src/lib/foo.test.ts')];
+    const all = tree.map((n) => n.path);
+
+    const candidats = findUncoveredFiles(findSourceFiles(tree), all);
+    const cibles = candidats.map((p) => p.replace(/\.(ts|tsx)$/, '.test.$1'));
+
+    expect(cibles).not.toContain('src/lib/foo.test.test.ts');
+    expect(cibles.some((p) => /\.test\.test\./.test(p))).toBe(false);
+  });
+
+  it('propose bien la source reellement non couverte', () => {
+    const tree = [
+      blob('src/lib/couvert.ts'),
+      blob('src/lib/couvert.test.ts'),
+      blob('src/lib/orphelin.ts'),
+    ];
+    const all = tree.map((n) => n.path);
+
+    expect(findUncoveredFiles(findSourceFiles(tree), all)).toEqual(['src/lib/orphelin.ts']);
+  });
+
+  it('reconnait .spec comme une couverture valide', () => {
+    const tree = [blob('src/lib/foo.ts'), blob('src/lib/foo.spec.ts')];
+    const all = tree.map((n) => n.path);
+
+    expect(findUncoveredFiles(findSourceFiles(tree), all)).toEqual([]);
+  });
+});
+
+describe('generateTestSkeleton', () => {
+  it('n importe que ce qu il utilise — sinon le lint de la cible casse', () => {
+    const out = generateTestSkeleton('src/lib/foo.ts', ['doStuff']);
+
+    expect(out).toContain("import { describe, it } from 'vitest';");
+    expect(out).not.toContain('expect');
+  });
+
+  it('liste un it.todo par export', () => {
+    const out = generateTestSkeleton('src/lib/foo.ts', ['alpha', 'beta']);
+
+    expect(out).toContain("it.todo('should test alpha');");
+    expect(out).toContain("it.todo('should test beta');");
+  });
+
+  it('reste valide sans aucun export detecte', () => {
+    const out = generateTestSkeleton('src/lib/foo.ts', []);
+
+    expect(out).toContain("it.todo('should test exported functionality');");
+    expect(out).toContain("describe('foo', () => {");
+  });
+});

--- a/scripts/test-scaffold.ts
+++ b/scripts/test-scaffold.ts
@@ -9,6 +9,7 @@
  */
 
 import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { KNOWN_PROJECTS, GITHUB_OWNER } from '../factory.config.js';
 import { sh, tmpDir } from './shell-utils.js';
 import type { TreeNode } from './types.js';
@@ -34,8 +35,19 @@ const isSkippedDir = (path: string): boolean => {
   return skipped.some((dir) => path.includes(`/${dir}/`) || path.startsWith(`${dir}/`));
 };
 
-const isSkippedFile = (path: string): boolean => {
-  const skipped = [/\.d\.ts$/, /\.config\.(ts|tsx|js)$/, /index\.ts$/, /index\.tsx$/];
+export const isSkippedFile = (path: string): boolean => {
+  const skipped = [
+    /\.d\.ts$/,
+    /\.config\.(ts|tsx|js)$/,
+    /index\.ts$/,
+    /index\.tsx$/,
+    // Un fichier de test n'est PAS une source a couvrir. Sans cette regle,
+    // `foo.test.ts` devenait un candidat : on cherchait `foo.test.test.ts`,
+    // absent, donc on le generait — puis `foo.test.test.test.ts` au passage
+    // suivant. C'est ce qui a produit les PR en echec sur CasaSync (#287,
+    // #295), le build cassant sur les squelettes empiles.
+    /\.(test|spec)\.(ts|tsx)$/,
+  ];
   return skipped.some((pattern) => pattern.test(path));
 };
 
@@ -44,7 +56,7 @@ const getRepoTree = (repo: string, branch: string): TreeNode[] => {
   return response.tree || [];
 };
 
-const findSourceFiles = (tree: TreeNode[]): string[] => {
+export const findSourceFiles = (tree: TreeNode[]): string[] => {
   return tree
     .filter(
       (node): node is TreeNode & { path: string } =>
@@ -57,7 +69,7 @@ const findSourceFiles = (tree: TreeNode[]): string[] => {
     .map((node) => node.path);
 };
 
-const findUncoveredFiles = (sourceFiles: string[], allFiles: string[]): string[] => {
+export const findUncoveredFiles = (sourceFiles: string[], allFiles: string[]): string[] => {
   return sourceFiles.filter((sourcePath) => {
     const testPath1 = sourcePath.replace(/\.(ts|tsx)$/, '.test.$1');
     const testPath2 = sourcePath.replace(/\.(ts|tsx)$/, '.spec.$1');
@@ -89,11 +101,14 @@ const extractExports = (content: string): string[] => {
   return Array.from(exports).filter((name) => name && name !== 'default');
 };
 
-const generateTestSkeleton = (filePath: string, exports: string[]): string => {
+export const generateTestSkeleton = (filePath: string, exports: string[]): string => {
   const importPath = filePath.replace(/\.(ts|tsx)$/, '');
   const fileName = importPath.split('/').pop() || 'module';
 
-  let content = `import { describe, it, expect } from 'vitest';\n`;
+  // `expect` n'est PAS importe : le squelette n'utilise que `describe` et
+  // `it.todo`. L'importer declenchait `@typescript-eslint/no-unused-vars` sur
+  // chaque fichier genere, et faisait echouer le build du depot cible.
+  let content = `import { describe, it } from 'vitest';\n`;
   content += `// TODO: import from '${importPath}';\n\n`;
 
   content += `describe('${fileName}', () => {\n`;
@@ -290,4 +305,9 @@ const main = (): void => {
   console.log('\nTest scaffold generation complete.');
 };
 
-main();
+// `main()` n'est appele QUE lors d'une execution directe (`pnpm test-scaffold`).
+// Sans ce garde-fou, un simple `import` depuis un test declencherait les appels
+// GitHub et la creation de PR — le fichier etait donc intestable.
+if (process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}


### PR DESCRIPTION
## Le problème

Le générateur produisait `foo.test.test.ts`, puis `foo.test.test.test.ts` au passage suivant. Les fichiers générés cassaient en plus le build du dépôt cible.

Constaté sur CasaSync : PR **#287** et **#295** (toutes deux fermées), build Vercel en échec sur **42 erreurs ESLint**, avec des fichiers comme `blocked-dates.test.test.test.ts`.

Ce sont **deux défauts indépendants**.

### 1. Non-idempotence

`isSkippedFile` n'excluait pas les fichiers de test. `findSourceFiles` retenait donc `foo.test.ts` comme une source à couvrir : il cherchait `foo.test.test.ts`, ne le trouvait pas, et le générait. Au passage suivant, ce nouveau fichier devenait à son tour candidat.

```
foo.ts → foo.test.ts → foo.test.test.ts → foo.test.test.test.ts → …
```

Correctif : ajout de `/\.(test|spec)\.(ts|tsx)$/` aux exclusions. La règle couvre aussi les suffixes déjà empilés par les anciens passages.

### 2. Squelettes non lintables

`generateTestSkeleton` importait `expect` alors que le squelette n'utilise que `describe` et `it.todo` — d'où `@typescript-eslint/no-unused-vars` sur **chaque** fichier généré.

```diff
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
```

## Testabilité

Le fichier appelait `main()` au chargement et n'exportait rien : un `import` depuis un test aurait déclenché les appels GitHub **et la création de PR**. Il était donc structurellement intestable.

- `main()` est maintenant gardé par une comparaison à `import.meta.url` — exécution directe uniquement, `pnpm test-scaffold` fonctionne à l'identique.
- Les fonctions pures sont exportées.

## Les tests

`scripts/test-scaffold.test.ts` — 12 tests qui importent les **vraies** fonctions.

C'est un écart assumé avec la convention du dépôt : les tests existants (`auto-fix-prettier.test.ts` par exemple) redéclarent les constantes dans le fichier de test et vérifient leur propre copie. Ils passent quoi qu'il arrive au code de production.

**Vérification que ces tests protègent vraiment :** en retirant les deux correctifs, **8 des 12 tests échouent**, dont `ne propose JAMAIS foo.test.test.ts`. Ce n'est pas une décoration.

## Vérification

| Contrôle | Résultat |
| --- | --- |
| `pnpm test` | **926 tests passants** (914 + les 12 ajoutés) |
| `pnpm lint` | 0 erreur |

## À noter

Le workflow **`Test Scaffold Generator` reste désactivé** (`disabled_manually`). Il est à réactiver manuellement après relecture de cette PR :

```
gh api -X PUT repos/thonyAGP/DevOps-Factory/actions/workflows/235815076/enable
```

`Self-Heal CI` est également désactivé, pour une raison distincte : il tournait deux fois par heure, 24 h/24, en poussant du code dans les dépôts cibles. Il avait notamment interprété une panne de quota GitHub Actions comme un défaut de code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
